### PR TITLE
Subclass QSlider and modify it to fire sliderMoved(int) on mouse scroll events

### DIFF
--- a/OpenKJ/OpenKJ.pro
+++ b/OpenKJ/OpenKJ.pro
@@ -218,7 +218,8 @@ SOURCES += main.cpp\
     dlgeq.cpp \
     audiofader.cpp \
     customlineedit.cpp \
-    updatechecker.cpp
+    updatechecker.cpp \
+    volslider.cpp
 
 HEADERS  += mainwindow.h \
     libCDG/include/libCDG.h \
@@ -382,7 +383,8 @@ HEADERS  += mainwindow.h \
     dlgeq.h \
     audiofader.h \
     customlineedit.h \
-    updatechecker.h
+    updatechecker.h \
+    volslider.h
 
 FORMS    += mainwindow.ui \
     dlgkeychange.ui \

--- a/OpenKJ/mainwindow.ui
+++ b/OpenKJ/mainwindow.ui
@@ -1419,7 +1419,7 @@ QPushButton:default {
                        </layout>
                       </item>
                       <item>
-                       <widget class="QSlider" name="sliderVolume">
+                       <widget class="VolSlider" name="sliderVolume">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
                           <horstretch>0</horstretch>
@@ -2301,7 +2301,7 @@ QPushButton:default {
                        </property>
                        <layout class="QHBoxLayout" name="horizontalLayout_4">
                         <item>
-                         <widget class="QSlider" name="sliderBmVolume">
+                         <widget class="VolSlider" name="sliderBmVolume">
                           <property name="focusPolicy">
                            <enum>Qt::NoFocus</enum>
                           </property>
@@ -2696,7 +2696,7 @@ QPushButton:default {
      <x>0</x>
      <y>0</y>
      <width>964</width>
-     <height>25</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -2887,6 +2887,11 @@ QPushButton:default {
    <class>CustomLineEdit</class>
    <extends>QLineEdit</extends>
    <header>customlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>VolSlider</class>
+   <extends>QSlider</extends>
+   <header location="global">volslider.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/OpenKJ/volslider.cpp
+++ b/OpenKJ/volslider.cpp
@@ -1,0 +1,13 @@
+#include "volslider.h"
+
+VolSlider::VolSlider(QWidget *parent) : QSlider(parent)
+{
+
+}
+
+
+void VolSlider::wheelEvent(QWheelEvent *event)
+{
+    QAbstractSlider::wheelEvent(event);
+    emit sliderMoved(this->value());
+}

--- a/OpenKJ/volslider.h
+++ b/OpenKJ/volslider.h
@@ -1,0 +1,22 @@
+#ifndef VOLSLIDER_H
+#define VOLSLIDER_H
+
+#include <QWidget>
+#include <QSlider>
+
+class VolSlider : public QSlider
+{
+    Q_OBJECT
+public:
+    explicit VolSlider(QWidget *parent = nullptr);
+
+signals:
+
+public slots:
+
+    // QWidget interface
+protected:
+    void wheelEvent(QWheelEvent *event);
+};
+
+#endif // VOLSLIDER_H


### PR DESCRIPTION
Fixes mouse scroll over volume sliders moving the slider but not affecting the volume