### PR TITLE
Fix issue with single-clicks in linux getting in the way of adding songs by changing current song

### DIFF
--- a/OpenKJ/mainwindow.cpp
+++ b/OpenKJ/mainwindow.cpp
@@ -769,7 +769,7 @@ void MainWindow::on_lineEdit_returnPressed()
     search();
 }
 
-void MainWindow::on_tableViewDB_activated(const QModelIndex &index)
+void MainWindow::on_tableViewDB_doubleClicked(const QModelIndex &index)
 {
     if (qModel->singer() >= 0)
     {
@@ -787,18 +787,11 @@ void MainWindow::on_buttonAddSinger_clicked()
 {
     dlgAddSinger->show();
 }
-
-
-void MainWindow::on_tableViewRotation_activated(const QModelIndex &index)
+bool MainWindow::checkChangeSong()
 {
-    if (index.column() < 3)
-    {
-        k2kTransition = false;
-        int singerId = index.sibling(index.row(),0).data().toInt();
-        QString nextSongPath = rotModel->nextSongPath(singerId);
-        if (nextSongPath != "")
-        {
-            if ((kAudioBackend->state() == AbstractAudioBackend::PlayingState) && (settings->showSongInterruptionWarning()))
+    switch (kAudioBackend->state()) {
+        case AbstractAudioBackend::PlayingState:
+            if (settings->showSongInterruptionWarning())
             {
                 QMessageBox msgBox(this);
                 QCheckBox *cb = new QCheckBox("Show this warning in the future");
@@ -813,11 +806,12 @@ void MainWindow::on_tableViewRotation_activated(const QModelIndex &index)
                 msgBox.exec();
                 if (msgBox.clickedButton() != yesButton)
                 {
-                    return;
+                    return false;
                 }
                 k2kTransition = true;
             }
-            if (kAudioBackend->state() == AbstractAudioBackend::PausedState)
+            break;
+        case AbstractAudioBackend::PausedState:
             {
                 if (settings->karaokeAutoAdvance())
                 {
@@ -827,21 +821,47 @@ void MainWindow::on_tableViewRotation_activated(const QModelIndex &index)
                 audioRecorder->stop();
                 kAudioBackend->stop(true);
             }
- //           play(nextSongPath);
- //           kAudioBackend->setPitchShift(rotModel->nextSongKeyChg(singerId));
-            rotDelegate->setCurrentSinger(singerId);
-            rotModel->setCurrentSinger(singerId);
-            curSinger = rotModel->getSingerName(singerId);
-            curArtist = rotModel->nextSongArtist(singerId);
-            curTitle = rotModel->nextSongTitle(singerId);
-            ui->labelArtist->setText(curArtist);
-            ui->labelTitle->setText(curTitle);
-            ui->labelSinger->setText(curSinger);
-            play(nextSongPath, k2kTransition);
-            kAudioBackend->setPitchShift(rotModel->nextSongKeyChg(singerId));
-            qModel->songSetPlayed(rotModel->nextSongQueueId(singerId));
-        }
+            break;
+
+    default: ;
     }
+    return true;
+}
+
+void MainWindow::activateSinger(int singerId )
+{
+    if (singerId < 0)
+        return;
+    k2kTransition = false;
+
+    QString nextSongPath = rotModel->nextSongPath(singerId);
+    if (nextSongPath != "")
+    {
+        if (!checkChangeSong())
+            return;
+
+        rotDelegate->setCurrentSinger(singerId);
+        rotModel->setCurrentSinger(singerId);
+        curSinger = rotModel->getSingerName(singerId);
+        curArtist = rotModel->nextSongArtist(singerId);
+        curTitle = rotModel->nextSongTitle(singerId);
+        ui->labelArtist->setText(curArtist);
+        ui->labelTitle->setText(curTitle);
+        ui->labelSinger->setText(curSinger);
+        play(nextSongPath, k2kTransition);
+        kAudioBackend->setPitchShift(rotModel->nextSongKeyChg(singerId));
+        qModel->songSetPlayed(rotModel->nextSongQueueId(singerId));
+    }
+}
+
+void MainWindow::on_tableViewRotation_activated(const QModelIndex &index)
+{
+    if (index.column() < 1)
+    {
+        int singerId = index.sibling(index.row(),0).data().toInt();
+        activateSinger(singerId);
+    }
+
 }
 
 void MainWindow::on_tableViewRotation_clicked(const QModelIndex &index)
@@ -878,7 +898,7 @@ void MainWindow::on_tableViewRotation_clicked(const QModelIndex &index)
         ui->tableViewQueue->clearSelection();
         return;
 
-        }
+    }
     if (index.column() == 3)
     {
         if (!rotModel->singerIsRegular(index.sibling(index.row(),0).data().toInt()))
@@ -907,44 +927,24 @@ void MainWindow::on_tableViewRotation_clicked(const QModelIndex &index)
     ui->gbxQueue->setTitle(QString("Song Queue - " + rotModel->getSingerName(index.sibling(index.row(),0).data().toInt())));
 }
 
-void MainWindow::on_tableViewQueue_activated(const QModelIndex &index)
+void MainWindow::on_tableViewQueue_doubleClicked(const QModelIndex &index)
 {
-    k2kTransition = false;
-    if (kAudioBackend->state() == AbstractAudioBackend::PlayingState)
-    {
-        if (settings->showSongInterruptionWarning())
-        {
-            QMessageBox msgBox(this);
-            QCheckBox *cb = new QCheckBox("Show this warning in the future");
-            cb->setChecked(settings->showSongInterruptionWarning());
-            msgBox.setIcon(QMessageBox::Warning);
-            msgBox.setText("Interrupt currenly playing karaoke song?");
-            msgBox.setInformativeText("There is currently a karaoke song playing.  If you continue, the current song will be stopped.  Are you sure?");
-            QPushButton *yesButton = msgBox.addButton(QMessageBox::Yes);
-            msgBox.addButton(QMessageBox::Cancel);
-            msgBox.setCheckBox(cb);
-            connect(cb, SIGNAL(toggled(bool)), settings, SLOT(setShowSongInterruptionWarning(bool)));
-            msgBox.exec();
-            if (msgBox.clickedButton() != yesButton)
-            {
-                return;
-            }
-        }
-        k2kTransition = true;
-    }
-    if (kAudioBackend->state() == AbstractAudioBackend::PausedState)
-    {
-        if (settings->karaokeAutoAdvance())
-        {
-            kAASkip = true;
-            cdgWindow->showAlert(false);
-        }
-        audioRecorder->stop();
-        kAudioBackend->stop(true);
-    }
+    playSongAtIndex(index);
+}
+
+void MainWindow::playSongAtIndex(const QModelIndex &index)
+{
     curSinger = rotModel->getSingerName(index.sibling(index.row(),1).data().toInt());
     curArtist = index.sibling(index.row(),3).data().toString();
     curTitle = index.sibling(index.row(),4).data().toString();
+
+    if (curTitle == "")
+        return;
+
+    k2kTransition = false;
+    if (!checkChangeSong())
+        return;
+
     ui->labelSinger->setText(curSinger);
     ui->labelArtist->setText(curArtist);
     ui->labelTitle->setText(curTitle);
@@ -1346,9 +1346,11 @@ void MainWindow::on_tableViewDB_customContextMenuRequested(const QPoint &pos)
     QModelIndex index = ui->tableViewDB->indexAt(pos);
     if (index.isValid())
     {
+        m_rtClickIndex = index;
         dbRtClickFile = index.sibling(index.row(), 5).data().toString();
         QMenu contextMenu(this);
         contextMenu.addAction("Preview", this, SLOT(previewCdg()));
+        contextMenu.addAction("Add to queue", this, SLOT(addSongToQueue()));
         contextMenu.addSeparator();
 //        contextMenu.addAction("Edit", this, SLOT(editSong()));
         contextMenu.addAction("Mark bad", this, SLOT(markSongBad()));
@@ -1400,6 +1402,7 @@ void MainWindow::on_tableViewQueue_customContextMenuRequested(const QPoint &pos)
         QModelIndex index = ui->tableViewQueue->indexAt(pos);
         if (index.isValid())
         {
+            m_rtClickIndex = index;
             dbRtClickFile = index.sibling(index.row(), 6).data().toString();
             m_rtClickQueueSongId = index.sibling(index.row(), 0).data().toInt();
             dlgKeyChange->setActiveSong(m_rtClickQueueSongId);
@@ -1407,6 +1410,7 @@ void MainWindow::on_tableViewQueue_customContextMenuRequested(const QPoint &pos)
             contextMenu.addAction("Preview", this, SLOT(previewCdg()));
             contextMenu.addAction("Set Key Change", this, SLOT(setKeyChange()));
             contextMenu.addAction("Toggle played", this, SLOT(toggleQueuePlayed()));
+            contextMenu.addAction("Play now", this, SLOT(playFileNow()));
             contextMenu.exec(QCursor::pos());
         }
     }
@@ -1440,6 +1444,11 @@ void MainWindow::toggleQueuePlayed()
     qModel->songSetPlayed(m_rtClickQueueSongId, !qModel->getSongPlayed(m_rtClickQueueSongId));
 }
 
+void MainWindow::playFileNow()
+{
+    playSongAtIndex(m_rtClickIndex);
+}
+
 void MainWindow::regularNameConflict(QString name)
 {
     QMessageBox::warning(this, "Regular singer exists!","A regular singer named " + name + " already exists. You must either delete or rename the existing regular first, or rename the new regular singer and try again. The operation has been cancelled.",QMessageBox::Ok);
@@ -1461,6 +1470,20 @@ void MainWindow::previewCdg()
 void MainWindow::editSong()
 {
 
+}
+
+void MainWindow::addSongToQueue()
+{
+    if (qModel->singer() >= 0)
+    {
+        qModel->songAdd(m_rtClickIndex.sibling(m_rtClickIndex.row(),0).data().toInt());
+    }
+    else
+    {
+        QMessageBox msgBox;
+        msgBox.setText("No singer selected.  You must select a singer before you can double-click to add to a queue.");
+        msgBox.exec();
+    }
 }
 
 void MainWindow::markSongBad()
@@ -2453,4 +2476,16 @@ void MainWindow::on_tabWidget_currentChanged(int index)
         autosizeViews();
         kNeedAutoSize = false;
     }
+}
+
+void MainWindow::on_pushButtonActivateSinger_clicked()
+{
+    int singerId = qModel->singer();
+
+    activateSinger(singerId);
+}
+
+void MainWindow::on_pushButtonPlayNow_clicked()
+{
+    playSongAtIndex(ui->tableViewQueue->currentIndex());
 }

--- a/OpenKJ/mainwindow.h
+++ b/OpenKJ/mainwindow.h
@@ -114,6 +114,7 @@ private:
     int sortColDB;
     int sortDirDB;
     QString dbRtClickFile;
+    QModelIndex m_rtClickIndex;
     QString curSinger;
     QString curArtist;
     QString curTitle;
@@ -159,11 +160,11 @@ private slots:
     void on_buttonStop_clicked();
     void on_buttonPause_clicked();
     void on_lineEdit_returnPressed();
-    void on_tableViewDB_activated(const QModelIndex &index);
+    void on_tableViewDB_doubleClicked(const QModelIndex &index);
     void on_buttonAddSinger_clicked();
     void on_tableViewRotation_activated(const QModelIndex &index);
     void on_tableViewRotation_clicked(const QModelIndex &index);
-    void on_tableViewQueue_activated(const QModelIndex &index);
+    void on_tableViewQueue_doubleClicked(const QModelIndex &index);
     void on_actionManage_DB_triggered();
     void on_actionExport_Regulars_triggered();
     void on_actionImport_Regulars_triggered();
@@ -195,11 +196,13 @@ private slots:
     void on_sliderProgress_sliderReleased();
     void setKeyChange();
     void toggleQueuePlayed();
+    void playFileNow();
     void regularNameConflict(QString name);
     void regularAddError(QString errorText);
     void previewCdg();
     void editSong();
     void markSongBad();
+    void addSongToQueue();
     void setShowBgImage(bool show);
     void onBgImageChange();
     void karaokeAATimerTimeout();
@@ -258,9 +261,14 @@ private slots:
     void appFontChanged(QFont font);
 
     void on_tabWidget_currentChanged(int index);
+    void on_pushButtonActivateSinger_clicked();
+    void on_pushButtonPlayNow_clicked();
 
 protected:
+    bool checkChangeSong();
     void closeEvent(QCloseEvent *event);
+    void activateSinger(int singerId);
+    void playSongAtIndex(const QModelIndex &index);
 
     // QWidget interface
 protected:

--- a/OpenKJ/mainwindow.ui
+++ b/OpenKJ/mainwindow.ui
@@ -558,6 +558,20 @@ QPushButton:default {
                       </property>
                      </spacer>
                     </item>
+                    <item>
+                     <widget class="QPushButton" name="pushButtonPlayNow">
+                      <property name="text">
+                       <string>Play Now</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="pushButtonActivateSinger">
+                      <property name="text">
+                       <string>Make Active</string>
+                      </property>
+                     </widget>
+                    </item>
                    </layout>
                   </widget>
                  </item>
@@ -2659,7 +2673,7 @@ QPushButton:default {
      <x>0</x>
      <y>0</y>
      <width>1309</width>
-     <height>25</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -2678,7 +2692,7 @@ QPushButton:default {
    </widget>
    <widget class="QMenu" name="menuKaraoke">
     <property name="title">
-     <string>Karaoke</string>
+     <string>&amp;Karaoke</string>
     </property>
     <addaction name="actionManage_Karaoke_DB"/>
     <addaction name="actionRegulars"/>
@@ -2691,11 +2705,11 @@ QPushButton:default {
    </widget>
    <widget class="QMenu" name="menuBreak_Music">
     <property name="title">
-     <string>Break Music</string>
+     <string>Break &amp;Music</string>
     </property>
     <widget class="QMenu" name="menuPlaylists">
      <property name="title">
-      <string>Playlist</string>
+      <string>&amp;Playlist</string>
      </property>
      <addaction name="actionPlaylistNew"/>
      <addaction name="actionPlaylistImport"/>
@@ -2709,7 +2723,7 @@ QPushButton:default {
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
-     <string>Help</string>
+     <string>He&amp;lp</string>
     </property>
     <addaction name="actionAbout"/>
    </widget>
@@ -2732,17 +2746,17 @@ QPushButton:default {
   </action>
   <action name="actionRegulars">
    <property name="text">
-    <string>Regulars</string>
+    <string>&amp;Regulars</string>
    </property>
   </action>
   <action name="actionIncoming_Requests">
    <property name="text">
-    <string>Incoming Requests</string>
+    <string>I&amp;ncoming Requests</string>
    </property>
   </action>
   <action name="actionSettings">
    <property name="text">
-    <string>Settings</string>
+    <string>&amp;Settings</string>
    </property>
   </action>
   <action name="actionExport_Regular_Singers">
@@ -2752,22 +2766,22 @@ QPushButton:default {
   </action>
   <action name="actionExport_Regulars">
    <property name="text">
-    <string>Export Regulars</string>
+    <string>&amp;Export Regulars</string>
    </property>
   </action>
   <action name="actionImport_Regulars">
    <property name="text">
-    <string>Import Regulars</string>
+    <string>&amp;Import Regulars</string>
    </property>
   </action>
   <action name="actionManage_Break_DB">
    <property name="text">
-    <string>Manage Break DB</string>
+    <string>&amp;Manage Break DB</string>
    </property>
   </action>
   <action name="actionManage_Karaoke_DB">
    <property name="text">
-    <string>Manage Karaoke DB</string>
+    <string>&amp;Manage Karaoke DB</string>
    </property>
   </action>
   <action name="actionRegulars_2">
@@ -2785,7 +2799,7 @@ QPushButton:default {
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Display Metadata</string>
+    <string>&amp;Display Metadata</string>
    </property>
   </action>
   <action name="actionDisplay_Filenames">
@@ -2793,32 +2807,32 @@ QPushButton:default {
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Display Filenames</string>
+    <string>Display &amp;Filenames</string>
    </property>
   </action>
   <action name="actionPlaylistNew">
    <property name="text">
-    <string>New</string>
+    <string>&amp;New</string>
    </property>
   </action>
   <action name="actionPlaylistImport">
    <property name="text">
-    <string>Import</string>
+    <string>&amp;Import</string>
    </property>
   </action>
   <action name="actionPlaylistExport">
    <property name="text">
-    <string>Export Current</string>
+    <string>&amp;Export Current</string>
    </property>
   </action>
   <action name="actionPlaylistDelete">
    <property name="text">
-    <string>Delete Current</string>
+    <string>&amp;Delete Current</string>
    </property>
   </action>
   <action name="actionAbout">
    <property name="text">
-    <string>About</string>
+    <string>&amp;About</string>
    </property>
   </action>
   <action name="actionAutoplay_mode">
@@ -2826,22 +2840,22 @@ QPushButton:default {
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Autoplay mode</string>
+    <string>&amp;Autoplay mode</string>
    </property>
   </action>
   <action name="actionSongbook_Generator">
    <property name="text">
-    <string>Songbook Generator</string>
+    <string>Songbook &amp;Generator</string>
    </property>
   </action>
   <action name="actionEqualizer">
    <property name="text">
-    <string>Equalizer</string>
+    <string>&amp;Equalizer</string>
    </property>
   </action>
   <action name="actionSong_Shop">
    <property name="text">
-    <string>Song Shop</string>
+    <string>&amp;Song Shop</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
 - In both user and song choice boxes, single-clicking on an item was requesting the song/singer to play
 - For singer, made 'activate' only work in the first (microphone icon) column
 - Made both singer and song list explicitly double-click otherwise
 - Added buttons to the bottom of the singer's song queue so the operation could be done with single clicks
 - Added context menu items for add-to queue and play now.
