### PR TITLE
Various  tidy + new buttons

### DIFF
--- a/OpenKJ/OpenKJ.pro
+++ b/OpenKJ/OpenKJ.pro
@@ -491,3 +491,6 @@ RESOURCES += resources.qrc
 
 
 DISTFILES +=
+greaterThan(QT_MAJOR_VERSION, 4) {
+    QMAKE_CXXFLAGS += -std=c++11
+}

--- a/OpenKJ/bmdbtablemodel.h
+++ b/OpenKJ/bmdbtablemodel.h
@@ -36,6 +36,15 @@ private:
 public:
     explicit BmDbTableModel(QObject *parent = 0, QSqlDatabase db = QSqlDatabase());
     enum {SORT_ARTIST=1,SORT_TITLE=2,SORT_FILENAME=4,SORT_DURATION=5};
+    enum {
+        dbBmDb_Songid = 0,
+        dbBmDb_Artist = 1,
+        dbBmDb_Title = 2,
+        dbBmDb_Path = 3,
+        dbBmDb_Filename = 4,
+        dbBmDb_Duration = 5,
+        dbBmDb_Searchstring = 6
+    };
 
     // QAbstractItemModel interface
 public:

--- a/OpenKJ/bmpltablemodel.h
+++ b/OpenKJ/bmpltablemodel.h
@@ -33,6 +33,16 @@ private:
 
 public:
     explicit BmPlTableModel(QObject *parent = 0, QSqlDatabase db = QSqlDatabase());
+    enum {
+	dbBmPl_Plsongid = 0,
+	dbBmPl_Playlist = 1,
+	dbBmPl_Position = 2,
+	dbBmPl_Artist = 3,
+	dbBmPl_Title = 4,
+	dbBmPl_Filename = 5,
+	dbBmPl_Duration = 6,
+	dbBmPl_Path = 7
+    };
     void moveSong(int oldPosition, int newPosition);
     void addSong(int songId);
     void insertSong(int songId, int position);

--- a/OpenKJ/dbtablemodel.h
+++ b/OpenKJ/dbtablemodel.h
@@ -41,6 +41,9 @@ private:
 public:
     explicit DbTableModel(QObject *parent = 0, QSqlDatabase db = QSqlDatabase());
     enum {SORT_ARTIST=1,SORT_TITLE=2,SORT_SONGID=3,SORT_DURATION=4};
+
+    enum { dbSong_SongId = 0, dbSong_Artist = 1, dbSong_Title = 2, dbSong_DiscId = 3, dbSong_Duration = 4, dbSong_Path = 5, dbSong_Filename = 6, dbSong_SearchString = 7 };
+
     void search(QString searchString);
     QMimeData *mimeData(const QModelIndexList &indexes) const;
     Qt::ItemFlags flags(const QModelIndex &index) const;

--- a/OpenKJ/dlgsettings.cpp
+++ b/OpenKJ/dlgsettings.cpp
@@ -199,8 +199,9 @@ DlgSettings::DlgSettings(AbstractAudioBackend *AudioBackend, AbstractAudioBacken
     connect(ui->cbxCheckUpdates, SIGNAL(clicked(bool)), settings, SLOT(setCheckUpdates(bool)));
     connect(ui->comboBoxUpdateBranch, SIGNAL(currentIndexChanged(int)), settings, SLOT(setUpdatesBranch(int)));
     ui->lineEditDownloadsDir->setText(settings->storeDownloadDir());
-    ui->listWidget->setMinimumWidth(QFontMetrics(settings->applicationFont()).width("  Network  "));
-    ui->frame->setMinimumWidth(QFontMetrics(settings->applicationFont()).width("  Network  "));
+    int minWidth = 5+ qMax(72,QFontMetrics(settings->applicationFont()).width("  Network  "));
+    ui->listWidget->setMinimumWidth(minWidth);
+    ui->frame->setMinimumWidth(minWidth);
     adjustSize();
 
 }

--- a/OpenKJ/dlgsongshop.cpp
+++ b/OpenKJ/dlgsongshop.cpp
@@ -78,5 +78,6 @@ void DlgSongShop::autoSizeView()
 
 void DlgSongShop::resizeEvent(QResizeEvent *event)
 {
+    Q_UNUSED(event);
     autoSizeView();
 }

--- a/OpenKJ/mainwindow.cpp
+++ b/OpenKJ/mainwindow.cpp
@@ -809,18 +809,11 @@ void MainWindow::on_buttonAddSinger_clicked()
 {
     dlgAddSinger->show();
 }
-
-
-void MainWindow::on_tableViewRotation_doubleClicked(const QModelIndex &index)
+bool MainWindow::checkChangeSong()
 {
-    if (index.column() < 3)
-    {
-        k2kTransition = false;
-        int singerId = index.sibling(index.row(),0).data().toInt();
-        QString nextSongPath = rotModel->nextSongPath(singerId);
-        if (nextSongPath != "")
-        {
-            if ((kAudioBackend->state() == AbstractAudioBackend::PlayingState) && (settings->showSongInterruptionWarning()))
+    switch (kAudioBackend->state()) {
+        case AbstractAudioBackend::PlayingState:
+            if (settings->showSongInterruptionWarning())
             {
                 QMessageBox msgBox(this);
                 QCheckBox *cb = new QCheckBox("Show this warning in the future");
@@ -835,11 +828,12 @@ void MainWindow::on_tableViewRotation_doubleClicked(const QModelIndex &index)
                 msgBox.exec();
                 if (msgBox.clickedButton() != yesButton)
                 {
-                    return;
+                    return false;
                 }
                 k2kTransition = true;
             }
-            if (kAudioBackend->state() == AbstractAudioBackend::PausedState)
+            break;
+        case AbstractAudioBackend::PausedState:
             {
                 if (settings->karaokeAutoAdvance())
                 {
@@ -849,21 +843,52 @@ void MainWindow::on_tableViewRotation_doubleClicked(const QModelIndex &index)
                 audioRecorder->stop();
                 kAudioBackend->stop(true);
             }
- //           play(nextSongPath);
- //           kAudioBackend->setPitchShift(rotModel->nextSongKeyChg(singerId));
-            rotDelegate->setCurrentSinger(singerId);
-            rotModel->setCurrentSinger(singerId);
-            curSinger = rotModel->getSingerName(singerId);
-            curArtist = rotModel->nextSongArtist(singerId);
-            curTitle = rotModel->nextSongTitle(singerId);
-            ui->labelArtist->setText(curArtist);
-            ui->labelTitle->setText(curTitle);
-            ui->labelSinger->setText(curSinger);
-            play(nextSongPath, k2kTransition);
-            kAudioBackend->setPitchShift(rotModel->nextSongKeyChg(singerId));
-            qModel->songSetPlayed(rotModel->nextSongQueueId(singerId));
-        }
+            break;
+
+    default: ;
     }
+    return true;
+}
+
+void MainWindow::activateSinger(int singerId )
+{
+    if (singerId < 0)
+        return;
+    k2kTransition = false;
+
+    QString nextSongPath = rotModel->nextSongPath(singerId);
+    if (nextSongPath != "")
+    {
+        if (!checkChangeSong())
+            return;
+
+        rotDelegate->setCurrentSinger(singerId);
+        rotModel->setCurrentSinger(singerId);
+        curSinger = rotModel->getSingerName(singerId);
+        curArtist = rotModel->nextSongArtist(singerId);
+        curTitle = rotModel->nextSongTitle(singerId);
+        ui->labelArtist->setText(curArtist);
+        ui->labelTitle->setText(curTitle);
+        ui->labelSinger->setText(curSinger);
+        play(nextSongPath, k2kTransition);
+        kAudioBackend->setPitchShift(rotModel->nextSongKeyChg(singerId));
+        qModel->songSetPlayed(rotModel->nextSongQueueId(singerId));
+    }
+}
+
+void MainWindow::on_tableViewRotation_activated(const QModelIndex &index)
+{
+    if (index.column() < 1)
+    {
+        int singerId = index.sibling(index.row(),0).data().toInt();
+        activateSinger(singerId);
+    }
+
+}
+void MainWindow::on_tableViewRotation_doubleClicked(const QModelIndex &index)
+{
+    int singerId = index.sibling(index.row(),0).data().toInt();
+    activateSinger(singerId);
 }
 
 void MainWindow::on_tableViewRotation_clicked(const QModelIndex &index)
@@ -900,7 +925,7 @@ void MainWindow::on_tableViewRotation_clicked(const QModelIndex &index)
         ui->tableViewQueue->clearSelection();
         return;
 
-        }
+    }
     if (index.column() == 3)
     {
         if (!rotModel->singerIsRegular(index.sibling(index.row(),0).data().toInt()))
@@ -931,42 +956,22 @@ void MainWindow::on_tableViewRotation_clicked(const QModelIndex &index)
 
 void MainWindow::on_tableViewQueue_doubleClicked(const QModelIndex &index)
 {
-    k2kTransition = false;
-    if (kAudioBackend->state() == AbstractAudioBackend::PlayingState)
-    {
-        if (settings->showSongInterruptionWarning())
-        {
-            QMessageBox msgBox(this);
-            QCheckBox *cb = new QCheckBox("Show this warning in the future");
-            cb->setChecked(settings->showSongInterruptionWarning());
-            msgBox.setIcon(QMessageBox::Warning);
-            msgBox.setText("Interrupt currenly playing karaoke song?");
-            msgBox.setInformativeText("There is currently a karaoke song playing.  If you continue, the current song will be stopped.  Are you sure?");
-            QPushButton *yesButton = msgBox.addButton(QMessageBox::Yes);
-            msgBox.addButton(QMessageBox::Cancel);
-            msgBox.setCheckBox(cb);
-            connect(cb, SIGNAL(toggled(bool)), settings, SLOT(setShowSongInterruptionWarning(bool)));
-            msgBox.exec();
-            if (msgBox.clickedButton() != yesButton)
-            {
-                return;
-            }
-        }
-        k2kTransition = true;
-    }
-    if (kAudioBackend->state() == AbstractAudioBackend::PausedState)
-    {
-        if (settings->karaokeAutoAdvance())
-        {
-            kAASkip = true;
-            cdgWindow->showAlert(false);
-        }
-        audioRecorder->stop();
-        kAudioBackend->stop(true);
-    }
+    playSongAtIndex(index);
+}
+
+void MainWindow::playSongAtIndex(const QModelIndex &index)
+{
     curSinger = rotModel->getSingerName(index.sibling(index.row(),1).data().toInt());
     curArtist = index.sibling(index.row(),3).data().toString();
     curTitle = index.sibling(index.row(),4).data().toString();
+
+    if (curTitle == "")
+        return;
+
+    k2kTransition = false;
+    if (!checkChangeSong())
+        return;
+
     ui->labelSinger->setText(curSinger);
     ui->labelArtist->setText(curArtist);
     ui->labelTitle->setText(curTitle);
@@ -1379,9 +1384,11 @@ void MainWindow::on_tableViewDB_customContextMenuRequested(const QPoint &pos)
     QModelIndex index = ui->tableViewDB->indexAt(pos);
     if (index.isValid())
     {
+        m_rtClickIndex = index;
         dbRtClickFile = index.sibling(index.row(), 5).data().toString();
         QMenu contextMenu(this);
         contextMenu.addAction("Preview", this, SLOT(previewCdg()));
+        contextMenu.addAction("Add to queue", this, SLOT(addSongToQueue()));
         contextMenu.addSeparator();
         contextMenu.addAction("Edit", this, SLOT(editSong()));
         contextMenu.addAction("Mark bad", this, SLOT(markSongBad()));
@@ -1433,6 +1440,7 @@ void MainWindow::on_tableViewQueue_customContextMenuRequested(const QPoint &pos)
         QModelIndex index = ui->tableViewQueue->indexAt(pos);
         if (index.isValid())
         {
+            m_rtClickIndex = index;
             dbRtClickFile = index.sibling(index.row(), 6).data().toString();
             m_rtClickQueueSongId = index.sibling(index.row(), 0).data().toInt();
             dlgKeyChange->setActiveSong(m_rtClickQueueSongId);
@@ -1440,6 +1448,7 @@ void MainWindow::on_tableViewQueue_customContextMenuRequested(const QPoint &pos)
             contextMenu.addAction("Preview", this, SLOT(previewCdg()));
             contextMenu.addAction("Set Key Change", this, SLOT(setKeyChange()));
             contextMenu.addAction("Toggle played", this, SLOT(toggleQueuePlayed()));
+            contextMenu.addAction("Play now", this, SLOT(playFileNow()));
             contextMenu.exec(QCursor::pos());
         }
     }
@@ -1471,6 +1480,11 @@ void MainWindow::setKeyChange()
 void MainWindow::toggleQueuePlayed()
 {
     qModel->songSetPlayed(m_rtClickQueueSongId, !qModel->getSongPlayed(m_rtClickQueueSongId));
+}
+
+void MainWindow::playFileNow()
+{
+    playSongAtIndex(m_rtClickIndex);
 }
 
 void MainWindow::regularNameConflict(QString name)
@@ -1696,6 +1710,20 @@ void MainWindow::editSong()
         }
     }
 
+}
+
+void MainWindow::addSongToQueue()
+{
+    if (qModel->singer() >= 0)
+    {
+        qModel->songAdd(m_rtClickIndex.sibling(m_rtClickIndex.row(),0).data().toInt());
+    }
+    else
+    {
+        QMessageBox msgBox;
+        msgBox.setText("No singer selected.  You must select a singer before you can double-click to add to a queue.");
+        msgBox.exec();
+    }
 }
 
 void MainWindow::markSongBad()
@@ -2775,4 +2803,16 @@ void MainWindow::on_sliderBmPosition_sliderReleased()
     bmAudioBackend->setPosition(ui->sliderBmPosition->value());
     sliderBmPositionPressed = false;
     qWarning() << "BM slider up.  Position:" << ui->sliderBmPosition->value();
+}
+
+void MainWindow::on_pushButtonActivateSinger_clicked()
+{
+    int singerId = qModel->singer();
+
+    activateSinger(singerId);
+}
+
+void MainWindow::on_pushButtonPlayNow_clicked()
+{
+    playSongAtIndex(ui->tableViewQueue->currentIndex());
 }

--- a/OpenKJ/mainwindow.cpp
+++ b/OpenKJ/mainwindow.cpp
@@ -179,9 +179,11 @@ MainWindow::MainWindow(QWidget *parent) :
     qDelegate = new QueueItemDelegate(this);
     rotModel = new RotationModel(this, database);
     rotModel->select();
-    ui->tableViewDB->hideColumn(0);
-    ui->tableViewDB->hideColumn(5);
-    ui->tableViewDB->hideColumn(6);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_SongId);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_Path);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_Filename);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_SearchString);
+
     ui->tableViewRotation->setModel(rotModel);
     rotDelegate = new RotationItemDelegate(this);
     ui->tableViewRotation->setItemDelegate(rotDelegate);
@@ -285,30 +287,30 @@ MainWindow::MainWindow(QWidget *parent) :
     qWarning() << "Refreshing rotation data";
     rotationDataChanged();
     qWarning() << "Adjusting karaoke listviews column visibility and state";
-    ui->tableViewDB->hideColumn(0);
-    ui->tableViewDB->hideColumn(5);
-    ui->tableViewDB->hideColumn(6);
-    ui->tableViewDB->hideColumn(7);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_SongId);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_Path);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_Filename);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_SearchString);
 //    ui->tableViewDB->horizontalHeader()->resizeSection(4,75);
-    ui->tableViewQueue->hideColumn(0);
-    ui->tableViewQueue->hideColumn(1);
-    ui->tableViewQueue->hideColumn(2);
-    ui->tableViewQueue->hideColumn(6);
-    ui->tableViewQueue->hideColumn(9);
+    ui->tableViewQueue->hideColumn(QueueModel::dbQueue_Qsongid);
+    ui->tableViewQueue->hideColumn(QueueModel::dbQueue_Singer);
+    ui->tableViewQueue->hideColumn(QueueModel::dbQueue_Song);
+    ui->tableViewQueue->hideColumn(QueueModel::dbQueue_Path);
+    ui->tableViewQueue->hideColumn(QueueModel::dbQueue_Position);
     ui->tableViewQueue->hideColumn(10);
     ui->tableViewQueue->hideColumn(11);
     ui->tableViewQueue->hideColumn(12);
     if (!kAudioBackend->canPitchShift())
     {
-        ui->tableViewQueue->hideColumn(7);
+        ui->tableViewQueue->hideColumn(QueueModel::dbQueue_Keychg);
     }
     qModel->setHeaderData(8, Qt::Horizontal,"");
     qModel->setHeaderData(7, Qt::Horizontal, "Key");
-    rotModel->setHeaderData(0,Qt::Horizontal,"");
-    rotModel->setHeaderData(1,Qt::Horizontal,"Singer");
-    rotModel->setHeaderData(3,Qt::Horizontal,"");
-    rotModel->setHeaderData(4,Qt::Horizontal,"");
-    ui->tableViewRotation->hideColumn(2);
+    rotModel->setHeaderData(RotationModel::dbRotation_Singerid,Qt::Horizontal,"");
+    rotModel->setHeaderData(RotationModel::dbRotation_Name,Qt::Horizontal,"Singer");
+    rotModel->setHeaderData(RotationModel::dbRotation_Regular,Qt::Horizontal,"");
+    rotModel->setHeaderData(RotationModel::dbRotation_Regularid,Qt::Horizontal,"");
+    ui->tableViewRotation->hideColumn(RotationModel::dbRotation_Position);
     qWarning() << "Adding singer count to status bar";
     ui->statusBar->addWidget(labelSingerCount);
 
@@ -320,7 +322,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
     bmPlaylistsModel = new QSqlTableModel(this, database);
     bmPlaylistsModel->setTable("bmplaylists");
-    bmPlaylistsModel->sort(2, Qt::AscendingOrder);
+    bmPlaylistsModel->sort(BmPlTableModel::dbBmPl_Position, Qt::AscendingOrder);
     bmDbDialog = new BmDbDialog(database,this);
     bmDbModel = new BmDbTableModel(this, database);
     bmDbModel->setTable("mem.bmsongs");
@@ -349,12 +351,12 @@ MainWindow::MainWindow(QWidget *parent) :
     settings->restoreSplitterState(ui->splitterBm);
 //    settings->restoreColumnWidths(ui->tableViewBmDb);
 //    settings->restoreColumnWidths(ui->tableViewBmPlaylist);
-    ui->tableViewBmDb->setColumnHidden(0, true);
-    ui->tableViewBmDb->setColumnHidden(3, true);
-    ui->tableViewBmDb->setColumnHidden(6, true);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Songid, true);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Path, true);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Searchstring, true);
 
-    ui->tableViewBmPlaylist->setColumnHidden(0, true);
-    ui->tableViewBmPlaylist->setColumnHidden(1, true);
+    ui->tableViewBmPlaylist->setColumnHidden(BmPlTableModel::dbBmPl_Plsongid, true);
+    ui->tableViewBmPlaylist->setColumnHidden(BmPlTableModel::dbBmPl_Playlist, true);
 
     settings->restoreSplitterState(ui->splitter_3);
 
@@ -695,10 +697,11 @@ void MainWindow::databaseUpdated()
 {
     dbModel->refreshCache();
     search();
-    ui->tableViewDB->hideColumn(0);
-    ui->tableViewDB->hideColumn(5);
-    ui->tableViewDB->hideColumn(6);
-    ui->tableViewDB->horizontalHeader()->resizeSection(4,75);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_SongId);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_Path);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_Filename);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_SearchString);
+    ui->tableViewDB->horizontalHeader()->resizeSection(DbTableModel::dbSong_Duration,75);
     settings->restoreColumnWidths(ui->tableViewDB);
     requestsDialog->databaseUpdateComplete();
     autosizeViews();
@@ -710,10 +713,11 @@ void MainWindow::databaseCleared()
     dbModel->select();
     rotModel->select();
     qModel->setSinger(-1);
-    ui->tableViewDB->hideColumn(0);
-    ui->tableViewDB->hideColumn(5);
-    ui->tableViewDB->hideColumn(6);
-    ui->tableViewDB->horizontalHeader()->resizeSection(4,75);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_SongId);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_Path);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_Filename);
+    ui->tableViewDB->hideColumn(DbTableModel::dbSong_SearchString);
+    ui->tableViewDB->horizontalHeader()->resizeSection(DbTableModel::dbSong_Duration,75);
     settings->restoreColumnWidths(ui->tableViewDB);
 }
 
@@ -795,7 +799,7 @@ void MainWindow::on_tableViewDB_doubleClicked(const QModelIndex &index)
 {
     if (qModel->singer() >= 0)
     {
-        qModel->songAdd(index.sibling(index.row(),0).data().toInt());
+        qModel->songAdd(index.sibling(index.row(),DbTableModel::dbSong_SongId).data().toInt());
     }
     else
     {
@@ -880,14 +884,14 @@ void MainWindow::on_tableViewRotation_activated(const QModelIndex &index)
 {
     if (index.column() < 1)
     {
-        int singerId = index.sibling(index.row(),0).data().toInt();
+        int singerId = index.sibling(index.row(),RotationModel::dbRotation_Singerid).data().toInt();
         activateSinger(singerId);
     }
 
 }
 void MainWindow::on_tableViewRotation_doubleClicked(const QModelIndex &index)
 {
-    int singerId = index.sibling(index.row(),0).data().toInt();
+    int singerId = index.sibling(index.row(),RotationModel::dbRotation_Singerid).data().toInt();
     activateSinger(singerId);
 }
 
@@ -913,7 +917,7 @@ void MainWindow::on_tableViewRotation_clicked(const QModelIndex &index)
                 return;
             }
         }
-        int singerId = index.sibling(index.row(),0).data().toInt();
+        int singerId = index.sibling(index.row(),RotationModel::dbRotation_Singerid).data().toInt();
         qModel->setSinger(-1);
         if (rotModel->currentSinger() == singerId)
         {
@@ -928,13 +932,13 @@ void MainWindow::on_tableViewRotation_clicked(const QModelIndex &index)
     }
     if (index.column() == 3)
     {
-        if (!rotModel->singerIsRegular(index.sibling(index.row(),0).data().toInt()))
+        if (!rotModel->singerIsRegular(index.sibling(index.row(),RotationModel::dbRotation_Singerid).data().toInt()))
         {
-            QString name = index.sibling(index.row(),1).data().toString();
+            QString name = index.sibling(index.row(),RotationModel::dbRotation_Name).data().toString();
             if (rotModel->regularExists(name))
                 QMessageBox::warning(this, "Naming conflict!","A regular singer named " + name + " already exists. You must either rename or delete the existing regular singer, or rename the singer being saved as a regular. The operation has been cancelled.",QMessageBox::Ok);
             else
-                rotModel->singerMakeRegular(index.sibling(index.row(),0).data().toInt());
+                rotModel->singerMakeRegular(index.sibling(index.row(),RotationModel::dbRotation_Singerid).data().toInt());
         }
         else
         {
@@ -946,12 +950,12 @@ void MainWindow::on_tableViewRotation_clicked(const QModelIndex &index)
             msgBox.exec();
             if (msgBox.clickedButton() == yesButton)
             {
-                rotModel->singerDisableRegularTracking(index.sibling(index.row(),0).data().toInt());
+                rotModel->singerDisableRegularTracking(index.sibling(index.row(),RotationModel::dbRotation_Singerid).data().toInt());
             }
         }
     }
-    qModel->setSinger(index.sibling(index.row(),0).data().toInt());
-    ui->gbxQueue->setTitle(QString("Song Queue - " + rotModel->getSingerName(index.sibling(index.row(),0).data().toInt())));
+    qModel->setSinger(index.sibling(index.row(),RotationModel::dbRotation_Singerid).data().toInt());
+    ui->gbxQueue->setTitle(QString("Song Queue - " + rotModel->getSingerName(index.sibling(index.row(),RotationModel::dbRotation_Singerid).data().toInt())));
 }
 
 void MainWindow::on_tableViewQueue_doubleClicked(const QModelIndex &index)
@@ -961,9 +965,9 @@ void MainWindow::on_tableViewQueue_doubleClicked(const QModelIndex &index)
 
 void MainWindow::playSongAtIndex(const QModelIndex &index)
 {
-    curSinger = rotModel->getSingerName(index.sibling(index.row(),1).data().toInt());
-    curArtist = index.sibling(index.row(),3).data().toString();
-    curTitle = index.sibling(index.row(),4).data().toString();
+    curSinger = rotModel->getSingerName(index.sibling(index.row(),QueueModel::dbQueue_Singer).data().toInt());
+    curArtist = index.sibling(index.row(),QueueModel::dbQueue_Artist).data().toString();
+    curTitle = index.sibling(index.row(),QueueModel::dbQueue_Title).data().toString();
 
     if (curTitle == "")
         return;
@@ -975,11 +979,12 @@ void MainWindow::playSongAtIndex(const QModelIndex &index)
     ui->labelSinger->setText(curSinger);
     ui->labelArtist->setText(curArtist);
     ui->labelTitle->setText(curTitle);
-    rotModel->setCurrentSinger(index.sibling(index.row(),1).data().toInt());
-    rotDelegate->setCurrentSinger(index.sibling(index.row(),1).data().toInt());
-    play(index.sibling(index.row(), 6).data().toString(), k2kTransition);
-    kAudioBackend->setPitchShift(index.sibling(index.row(),7).data().toInt());
-    qModel->songSetPlayed(index.sibling(index.row(),0).data().toInt());
+    int singer = index.sibling(index.row(),QueueModel::dbQueue_Singer).data().toInt();
+    rotModel->setCurrentSinger(singer);
+    rotDelegate->setCurrentSinger(singer);
+    play(index.sibling(index.row(), QueueModel::dbQueue_Path).data().toString(), k2kTransition);
+    kAudioBackend->setPitchShift(index.sibling(index.row(),QueueModel::dbQueue_Keychg).data().toInt());
+    qModel->songSetPlayed(index.sibling(index.row(),QueueModel::dbQueue_Qsongid).data().toInt());
 }
 
 void MainWindow::on_actionManage_DB_triggered()
@@ -1385,7 +1390,7 @@ void MainWindow::on_tableViewDB_customContextMenuRequested(const QPoint &pos)
     if (index.isValid())
     {
         m_rtClickIndex = index;
-        dbRtClickFile = index.sibling(index.row(), 5).data().toString();
+        dbRtClickFile = index.sibling(index.row(), DbTableModel::dbSong_Path).data().toString();
         QMenu contextMenu(this);
         contextMenu.addAction("Preview", this, SLOT(previewCdg()));
         contextMenu.addAction("Add to queue", this, SLOT(addSongToQueue()));
@@ -1401,7 +1406,7 @@ void MainWindow::on_tableViewRotation_customContextMenuRequested(const QPoint &p
     QModelIndex index = ui->tableViewRotation->indexAt(pos);
     if (index.isValid())
     {
-           m_rtClickRotationSingerId = index.sibling(index.row(),0).data().toInt();
+           m_rtClickRotationSingerId = index.sibling(index.row(),RotationModel::dbRotation_Singerid).data().toInt();
            QMenu contextMenu(this);
            contextMenu.addAction("Rename", this, SLOT(renameSinger()));
            contextMenu.exec(QCursor::pos());
@@ -1441,8 +1446,8 @@ void MainWindow::on_tableViewQueue_customContextMenuRequested(const QPoint &pos)
         if (index.isValid())
         {
             m_rtClickIndex = index;
-            dbRtClickFile = index.sibling(index.row(), 6).data().toString();
-            m_rtClickQueueSongId = index.sibling(index.row(), 0).data().toInt();
+            dbRtClickFile = index.sibling(index.row(), QueueModel::dbQueue_Path).data().toString();
+            m_rtClickQueueSongId = index.sibling(index.row(), QueueModel::dbQueue_Qsongid).data().toInt();
             dlgKeyChange->setActiveSong(m_rtClickQueueSongId);
             QMenu contextMenu(this);
             contextMenu.addAction("Preview", this, SLOT(previewCdg()));
@@ -1716,7 +1721,7 @@ void MainWindow::addSongToQueue()
 {
     if (qModel->singer() >= 0)
     {
-        qModel->songAdd(m_rtClickIndex.sibling(m_rtClickIndex.row(),0).data().toInt());
+        qModel->songAdd(m_rtClickIndex.sibling(m_rtClickIndex.row(),QueueModel::dbQueue_Qsongid).data().toInt());
     }
     else
     {
@@ -1905,17 +1910,17 @@ void MainWindow::bmDbUpdated()
     bmDbModel->refreshCache();
     bmDbModel->select();
     ui->comboBoxBmPlaylists->setCurrentIndex(0);
-    ui->tableViewBmDb->setColumnHidden(0, true);
-    ui->tableViewBmDb->setColumnHidden(3, true);
-    ui->tableViewBmDb->setColumnHidden(6, true);
-    ui->tableViewBmDb->setColumnHidden(4, !settings->bmShowFilenames());
-    ui->tableViewBmDb->horizontalHeader()->resizeSection(4, 100);
-    ui->tableViewBmDb->setColumnHidden(1, !settings->bmShowMetadata());
-    ui->tableViewBmDb->setColumnHidden(2, !settings->bmShowMetadata());
-    ui->tableViewBmDb->horizontalHeader()->resizeSection(1, 100);
-    ui->tableViewBmDb->horizontalHeader()->resizeSection(2, 100);
-    ui->tableViewBmDb->horizontalHeader()->setSectionResizeMode(5, QHeaderView::Fixed);
-    ui->tableViewBmDb->horizontalHeader()->resizeSection(5,75);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Songid, true);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Path, true);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Searchstring, true);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Filename, !settings->bmShowFilenames());
+    ui->tableViewBmDb->horizontalHeader()->resizeSection(BmDbTableModel::dbBmDb_Filename, 100);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Artist, !settings->bmShowMetadata());
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Title, !settings->bmShowMetadata());
+    ui->tableViewBmDb->horizontalHeader()->resizeSection(BmDbTableModel::dbBmDb_Artist, 100);
+    ui->tableViewBmDb->horizontalHeader()->resizeSection(BmDbTableModel::dbBmDb_Title, 100);
+    ui->tableViewBmDb->horizontalHeader()->setSectionResizeMode(BmDbTableModel::dbBmDb_Duration, QHeaderView::Fixed);
+    ui->tableViewBmDb->horizontalHeader()->resizeSection(BmDbTableModel::dbBmDb_Duration,75);
 }
 
 void MainWindow::bmDbCleared()
@@ -1924,29 +1929,29 @@ void MainWindow::bmDbCleared()
     bmDbModel->select();
     bmAddPlaylist("Default");
     ui->comboBoxBmPlaylists->setCurrentIndex(0);
-    ui->tableViewBmDb->setColumnHidden(0, true);
-    ui->tableViewBmDb->setColumnHidden(3, true);
-    ui->tableViewBmDb->setColumnHidden(6, true);
-    ui->tableViewBmDb->horizontalHeader()->setSectionResizeMode(5, QHeaderView::Fixed);
-    ui->tableViewBmDb->setColumnHidden(4, !settings->bmShowFilenames());
-    ui->tableViewBmDb->horizontalHeader()->resizeSection(4, 100);
-    ui->tableViewBmDb->setColumnHidden(1, !settings->bmShowMetadata());
-    ui->tableViewBmDb->setColumnHidden(2, !settings->bmShowMetadata());
-    ui->tableViewBmDb->horizontalHeader()->resizeSection(1, 100);
-    ui->tableViewBmDb->horizontalHeader()->resizeSection(2, 100);
-    ui->tableViewBmDb->horizontalHeader()->resizeSection(5,75);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Songid, true);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Path, true);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Searchstring, true);
+    ui->tableViewBmDb->horizontalHeader()->setSectionResizeMode(BmDbTableModel::dbBmDb_Duration, QHeaderView::Fixed);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Filename, !settings->bmShowFilenames());
+    ui->tableViewBmDb->horizontalHeader()->resizeSection(BmDbTableModel::dbBmDb_Filename, 100);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Artist, !settings->bmShowMetadata());
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Title, !settings->bmShowMetadata());
+    ui->tableViewBmDb->horizontalHeader()->resizeSection(BmDbTableModel::dbBmDb_Artist, 100);
+    ui->tableViewBmDb->horizontalHeader()->resizeSection(BmDbTableModel::dbBmDb_Title, 100);
+    ui->tableViewBmDb->horizontalHeader()->resizeSection(BmDbTableModel::dbBmDb_Duration,75);
 }
 
 void MainWindow::bmShowMetadata(bool checked)
 {
-    ui->tableViewBmDb->setColumnHidden(1, !checked);
-    ui->tableViewBmDb->setColumnHidden(2, !checked);
-    ui->tableViewBmDb->horizontalHeader()->resizeSection(1, 100);
-    ui->tableViewBmDb->horizontalHeader()->resizeSection(2, 100);
-    ui->tableViewBmPlaylist->setColumnHidden(3, !checked);
-    ui->tableViewBmPlaylist->setColumnHidden(4, !checked);
-    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(3, 100);
-    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(4, 100);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Artist, !checked);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Title, !checked);
+    ui->tableViewBmDb->horizontalHeader()->resizeSection(BmDbTableModel::dbBmDb_Artist, 100);
+    ui->tableViewBmDb->horizontalHeader()->resizeSection(BmDbTableModel::dbBmDb_Title, 100);
+    ui->tableViewBmPlaylist->setColumnHidden(BmPlTableModel::dbBmPl_Artist, !checked);
+    ui->tableViewBmPlaylist->setColumnHidden(BmPlTableModel::dbBmPl_Title, !checked);
+    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(BmPlTableModel::dbBmPl_Artist, 100);
+    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(BmPlTableModel::dbBmPl_Title, 100);
     settings->bmSetShowMetadata(checked);
 }
 
@@ -1955,8 +1960,8 @@ void MainWindow::bmShowFilenames(bool checked)
 {
     ui->tableViewBmDb->setColumnHidden(4, !checked);
     ui->tableViewBmDb->horizontalHeader()->resizeSection(4, 100);
-    ui->tableViewBmPlaylist->setColumnHidden(5, !checked);
-    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(5, 100);
+    ui->tableViewBmPlaylist->setColumnHidden(BmPlTableModel::dbBmPl_Filename, !checked);
+    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(BmPlTableModel::dbBmPl_Filename, 100);
     settings->bmSetShowFilenames(checked);
 }
 
@@ -1984,15 +1989,22 @@ void MainWindow::bmMediaStateChanged(AbstractAudioBackend::State newState)
             else
                 bmCurrentPosition = 0;
             bmAudioBackend->stop(true);
-            QString path = bmPlModel->index(bmCurrentPosition, 7).data().toString();
-            QString song = bmPlModel->index(bmCurrentPosition, 3).data().toString() + " - " + bmPlModel->index(bmCurrentPosition, 4).data().toString();
+            QString path = bmPlModel->index(bmCurrentPosition, BmPlTableModel::dbBmPl_Path).data().toString();
+            QString song = bmPlModel->index(bmCurrentPosition, BmPlTableModel::dbBmPl_Artist).data().toString() + " - "
+                + bmPlModel->index(bmCurrentPosition, BmPlTableModel::dbBmPl_Title).data().toString();
             QString nextSong;
             if (!ui->checkBoxBmBreak->isChecked())
             {
-            if (bmCurrentPosition == bmPlModel->rowCount() - 1)
-                nextSong = bmPlModel->index(0, 3).data().toString() + " - " + bmPlModel->index(0, 4).data().toString();
-            else
-                nextSong = bmPlModel->index(bmCurrentPosition + 1, 3).data().toString() + " - " + bmPlModel->index(bmCurrentPosition + 1, 4).data().toString();
+                if (bmCurrentPosition == bmPlModel->rowCount() - 1)
+                {
+                    nextSong = bmPlModel->index(0, BmPlTableModel::dbBmPl_Artist).data().toString() + " - "
+                        + bmPlModel->index(0, BmPlTableModel::dbBmPl_Title).data().toString();
+                }
+                else
+                {
+                    nextSong = bmPlModel->index(bmCurrentPosition + 1, BmPlTableModel::dbBmPl_Artist).data().toString() +
+                        " - " + bmPlModel->index(bmCurrentPosition + 1, BmPlTableModel::dbBmPl_Title).data().toString();
+                }
             }
             else
                 nextSong = "None - Breaking after current song";
@@ -2086,9 +2098,16 @@ void MainWindow::on_checkBoxBmBreak_toggled(bool checked)
     if (!checked)
     {
         if (bmCurrentPosition == bmPlModel->rowCount() - 1)
-            nextSong = bmPlModel->index(0, 3).data().toString() + " - " + bmPlModel->index(0, 4).data().toString();
+        {
+            nextSong = bmPlModel->index(0, BmPlTableModel::dbBmPl_Artist).data().toString() + " - " +
+                bmPlModel->index(0, BmPlTableModel::dbBmPl_Title).data().toString();
+        }
         else
-            nextSong = bmPlModel->index(bmCurrentPosition + 1, 3).data().toString() + " - " + bmPlModel->index(bmCurrentPosition + 1, 4).data().toString();
+        {
+            nextSong = bmPlModel->index(bmCurrentPosition + 1,
+                    BmPlTableModel::dbBmPl_Artist).data().toString() + " - " +
+                    bmPlModel->index(bmCurrentPosition + 1, BmPlTableModel::dbBmPl_Title).data().toString();
+        }
     }
     else
         nextSong = "None - Stopping after current song";
@@ -2097,7 +2116,7 @@ void MainWindow::on_checkBoxBmBreak_toggled(bool checked)
 
 void MainWindow::on_tableViewBmDb_doubleClicked(const QModelIndex &index)
 {
-    int songId = index.sibling(index.row(), 0).data().toInt();
+    int songId = index.sibling(index.row(), BmDbTableModel::dbBmDb_Songid).data().toInt();
     bmPlModel->addSong(songId);
 }
 
@@ -2116,15 +2135,22 @@ void MainWindow::on_tableViewBmPlaylist_doubleClicked(const QModelIndex &index)
     if (bmAudioBackend->state() == AbstractAudioBackend::PlayingState)
         bmAudioBackend->stop(false);
     bmCurrentPosition = index.row();
-    QString path = index.sibling(index.row(), 7).data().toString();
-    QString song = index.sibling(index.row(), 3).data().toString() + " - " + index.sibling(index.row(), 4).data().toString();
+    QString path = index.sibling(index.row(), BmPlTableModel::dbBmPl_Path).data().toString();
+    QString song = index.sibling(index.row(), BmPlTableModel::dbBmPl_Artist).data().toString() + " - " +
+        index.sibling(index.row(), BmPlTableModel::dbBmPl_Title).data().toString();
     QString nextSong;
     if (!ui->checkBoxBmBreak->isChecked())
     {
         if (bmCurrentPosition == bmPlModel->rowCount() - 1)
-            nextSong = bmPlModel->index(0, 3).data().toString() + " - " + bmPlModel->index(0, 4).data().toString();
+        {
+            nextSong = bmPlModel->index(0, BmPlTableModel::dbBmPl_Artist).data().toString() + " - " +
+                bmPlModel->index(0, BmPlTableModel::dbBmPl_Title).data().toString();
+        }
         else
-            nextSong = bmPlModel->index(bmCurrentPosition + 1, 3).data().toString() + " - " + bmPlModel->index(bmCurrentPosition + 1, 4).data().toString();
+        {
+            nextSong = bmPlModel->index(bmCurrentPosition + 1, BmPlTableModel::dbBmPl_Artist).data().toString() + " - " +
+                bmPlModel->index(bmCurrentPosition + 1, BmPlTableModel::dbBmPl_Title).data().toString();
+        }
     }
     else
         nextSong = "None - Breaking after current song";
@@ -2148,7 +2174,7 @@ bool MainWindow::bmPlaylistExists(QString name)
 {
     for (int i=0; i < bmPlaylistsModel->rowCount(); i++)
     {
-        if (bmPlaylistsModel->index(i,1).data().toString().toLower() == name.toLower())
+        if (bmPlaylistsModel->index(i,BmPlTableModel::dbBmPl_Playlist).data().toString().toLower() == name.toLower())
             return true;
     }
     return false;
@@ -2164,18 +2190,18 @@ void MainWindow::refreshSongDbCache()
 
 void MainWindow::on_actionDisplay_Metadata_toggled(bool arg1)
 {
-    ui->tableViewBmDb->setColumnHidden(1, !arg1);
-    ui->tableViewBmDb->setColumnHidden(2, !arg1);
-    ui->tableViewBmPlaylist->setColumnHidden(3, !arg1);
-    ui->tableViewBmPlaylist->setColumnHidden(4, !arg1);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Artist, !arg1);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Title, !arg1);
+    ui->tableViewBmPlaylist->setColumnHidden(BmPlTableModel::dbBmPl_Artist, !arg1);
+    ui->tableViewBmPlaylist->setColumnHidden(BmPlTableModel::dbBmPl_Title, !arg1);
     settings->bmSetShowMetadata(arg1);
     autosizeBmViews();
 }
 
 void MainWindow::on_actionDisplay_Filenames_toggled(bool arg1)
 {
-    ui->tableViewBmDb->setColumnHidden(4, !arg1);
-    ui->tableViewBmPlaylist->setColumnHidden(5, !arg1);
+    ui->tableViewBmDb->setColumnHidden(BmDbTableModel::dbBmDb_Filename, !arg1);
+    ui->tableViewBmPlaylist->setColumnHidden(BmPlTableModel::dbBmPl_Filename, !arg1);
     settings->bmSetShowFilenames(arg1);
     autosizeBmViews();
 }
@@ -2230,7 +2256,7 @@ void MainWindow::on_actionPlaylistImport_triggered()
                     bmPlaylistsModel->submitAll();
                     bmPlaylistsModel->select();
                     ui->comboBoxBmPlaylists->setCurrentIndex(index.row());
-                    bmPlModel->setCurrentPlaylist(bmPlaylistsModel->index(index.row(),0).data().toInt());
+                    bmPlModel->setCurrentPlaylist(bmPlaylistsModel->index(index.row(),BmPlTableModel::dbBmPl_Plsongid).data().toInt());
 
                 }
             }
@@ -2289,7 +2315,7 @@ void MainWindow::on_actionPlaylistExport_triggered()
         QTextStream out(&file);
         for (int i=0; i < bmPlModel->rowCount(); i++)
         {
-            out << bmPlModel->index(i, 7).data().toString() << "\n";
+            out << bmPlModel->index(i, BmPlTableModel::dbBmPl_Path).data().toString() << "\n";
         }
     }
 }
@@ -2313,7 +2339,7 @@ void MainWindow::on_actionPlaylistDelete_triggered()
             bmAddPlaylist("Default");
         }
         ui->comboBoxBmPlaylists->setCurrentIndex(0);
-        bmPlModel->setCurrentPlaylist(bmPlaylistsModel->index(0,0).data().toInt());
+        bmPlModel->setCurrentPlaylist(bmPlaylistsModel->index(0,BmPlTableModel::dbBmPl_Plsongid).data().toInt());
     }
 }
 
@@ -2383,9 +2409,9 @@ void MainWindow::setMultiPlayed()
     QModelIndex index;
 
     foreach(index, indexes) {
-        if (index.column() == 0)
+        if (index.column() == QueueModel::dbQueue_Qsongid)
         {
-            int queueId = index.sibling(index.row(), 0).data().toInt();
+            int queueId = index.sibling(index.row(), QueueModel::dbQueue_Qsongid).data().toInt();
             qWarning() << "Selected row: " << index.row() << " queueId: " << queueId;
             qModel->songSetPlayed(queueId);
         }
@@ -2398,9 +2424,9 @@ void MainWindow::setMultiUnplayed()
     QModelIndex index;
 
     foreach(index, indexes) {
-        if (index.column() == 0)
+        if (index.column() == QueueModel::dbQueue_Qsongid)
         {
-            int queueId = index.sibling(index.row(), 0).data().toInt();
+            int queueId = index.sibling(index.row(), QueueModel::dbQueue_Qsongid).data().toInt();
             qWarning() << "Selected row: " << index.row() << " queueId: " << queueId;
             qModel->songSetPlayed(queueId,false);
         }
@@ -2619,33 +2645,33 @@ void MainWindow::autosizeViews()
     int remainingSpace = ui->tableViewDB->width() - durationColSize - songidColSize;
     int artistColSize = (remainingSpace / 2) - 120;
     int titleColSize = (remainingSpace / 2) + 100;
-    ui->tableViewDB->horizontalHeader()->resizeSection(1, artistColSize);
-    ui->tableViewDB->horizontalHeader()->resizeSection(2, titleColSize);
-    ui->tableViewDB->horizontalHeader()->resizeSection(4, durationColSize);
-    ui->tableViewDB->horizontalHeader()->setSectionResizeMode(4, QHeaderView::Fixed);
-    ui->tableViewDB->horizontalHeader()->resizeSection(3, songidColSize);
+    ui->tableViewDB->horizontalHeader()->resizeSection(DbTableModel::dbSong_Artist, artistColSize);
+    ui->tableViewDB->horizontalHeader()->resizeSection(DbTableModel::dbSong_Title, titleColSize);
+    ui->tableViewDB->horizontalHeader()->resizeSection(DbTableModel::dbSong_Duration, durationColSize);
+    ui->tableViewDB->horizontalHeader()->setSectionResizeMode(DbTableModel::dbSong_Duration, QHeaderView::Fixed);
+    ui->tableViewDB->horizontalHeader()->resizeSection(DbTableModel::dbSong_DiscId, songidColSize);
 
     int iconWidth = fH + fH;
     int singerColSize = ui->tableViewRotation->width() - (iconWidth * 3) - 5;
-    ui->tableViewRotation->horizontalHeader()->resizeSection(0, iconWidth);
-    ui->tableViewRotation->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);
-    ui->tableViewRotation->horizontalHeader()->resizeSection(1, singerColSize);
-    ui->tableViewRotation->horizontalHeader()->resizeSection(3, iconWidth);
-    ui->tableViewRotation->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Fixed);
-    ui->tableViewRotation->horizontalHeader()->resizeSection(4, iconWidth);
-    ui->tableViewRotation->horizontalHeader()->setSectionResizeMode(4, QHeaderView::Fixed);
+    ui->tableViewRotation->horizontalHeader()->resizeSection(RotationModel::dbRotation_Singerid, iconWidth);
+    ui->tableViewRotation->horizontalHeader()->setSectionResizeMode(RotationModel::dbRotation_Singerid, QHeaderView::Fixed);
+    ui->tableViewRotation->horizontalHeader()->resizeSection(RotationModel::dbRotation_Name, singerColSize);
+    ui->tableViewRotation->horizontalHeader()->resizeSection(RotationModel::dbRotation_Regular, iconWidth);
+    ui->tableViewRotation->horizontalHeader()->setSectionResizeMode(RotationModel::dbRotation_Regular, QHeaderView::Fixed);
+    ui->tableViewRotation->horizontalHeader()->resizeSection(RotationModel::dbRotation_Regularid, iconWidth);
+    ui->tableViewRotation->horizontalHeader()->setSectionResizeMode(RotationModel::dbRotation_Regularid, QHeaderView::Fixed);
 
     int keyColSize = QFontMetrics(settings->applicationFont()).width("Key") + iconWidth;
     remainingSpace = ui->tableViewQueue->width() - iconWidth - keyColSize - songidColSize - 16;
     artistColSize = (remainingSpace / 2);
     titleColSize = (remainingSpace / 2);
-    ui->tableViewQueue->horizontalHeader()->resizeSection(3, artistColSize);
-    ui->tableViewQueue->horizontalHeader()->resizeSection(4, titleColSize);
-    ui->tableViewQueue->horizontalHeader()->resizeSection(5, songidColSize);
-    ui->tableViewQueue->horizontalHeader()->resizeSection(8, iconWidth);
-    ui->tableViewQueue->horizontalHeader()->setSectionResizeMode(8, QHeaderView::Fixed);
-    ui->tableViewQueue->horizontalHeader()->resizeSection(7, keyColSize);
-    ui->tableViewQueue->horizontalHeader()->setSectionResizeMode(7, QHeaderView::Fixed);
+    ui->tableViewQueue->horizontalHeader()->resizeSection(QueueModel::dbQueue_Artist, artistColSize);
+    ui->tableViewQueue->horizontalHeader()->resizeSection(QueueModel::dbQueue_Title, titleColSize);
+    ui->tableViewQueue->horizontalHeader()->resizeSection(QueueModel::dbQueue_Discid, songidColSize);
+    ui->tableViewQueue->horizontalHeader()->resizeSection(QueueModel::dbQueue_Played, iconWidth);
+    ui->tableViewQueue->horizontalHeader()->setSectionResizeMode(QueueModel::dbQueue_Played, QHeaderView::Fixed);
+    ui->tableViewQueue->horizontalHeader()->resizeSection(QueueModel::dbQueue_Keychg, keyColSize);
+    ui->tableViewQueue->horizontalHeader()->setSectionResizeMode(QueueModel::dbQueue_Keychg, QHeaderView::Fixed);
 
 
 }
@@ -2678,11 +2704,11 @@ void MainWindow::autosizeBmViews()
     {
         fnameColSize = remainingSpace;
     }
-    ui->tableViewBmDb->horizontalHeader()->resizeSection(1, artistColSize);
-    ui->tableViewBmDb->horizontalHeader()->resizeSection(2, titleColSize);
-    ui->tableViewBmDb->horizontalHeader()->resizeSection(4, fnameColSize);
-    ui->tableViewBmDb->horizontalHeader()->setSectionResizeMode(5, QHeaderView::Fixed);
-    ui->tableViewBmDb->horizontalHeader()->resizeSection(5, durationColSize);
+    ui->tableViewBmDb->horizontalHeader()->resizeSection(BmDbTableModel::dbBmDb_Artist, artistColSize);
+    ui->tableViewBmDb->horizontalHeader()->resizeSection(BmDbTableModel::dbBmDb_Title, titleColSize);
+    ui->tableViewBmDb->horizontalHeader()->resizeSection(BmDbTableModel::dbBmDb_Filename, fnameColSize);
+    ui->tableViewBmDb->horizontalHeader()->setSectionResizeMode(BmDbTableModel::dbBmDb_Duration, QHeaderView::Fixed);
+    ui->tableViewBmDb->horizontalHeader()->resizeSection(BmDbTableModel::dbBmDb_Duration, durationColSize);
 
     remainingSpace = ui->tableViewBmPlaylist->width() - durationColSize - (iconWidth * 2) - 5;
     //5=filename  6=Duration 3=artist 4=title
@@ -2701,14 +2727,14 @@ void MainWindow::autosizeBmViews()
     {
         fnameColSize = remainingSpace;
     }
-    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(3, artistColSize);
-    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(4, titleColSize);
-    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(5, fnameColSize);
-    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(6, durationColSize);
-    ui->tableViewBmPlaylist->horizontalHeader()->setSectionResizeMode(2,QHeaderView::Fixed);
-    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(2, iconWidth);
-    ui->tableViewBmPlaylist->horizontalHeader()->setSectionResizeMode(7, QHeaderView::Fixed);
-    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(7, iconWidth);
+    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(BmPlTableModel::dbBmPl_Artist, artistColSize);
+    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(BmPlTableModel::dbBmPl_Title, titleColSize);
+    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(BmPlTableModel::dbBmPl_Filename, fnameColSize);
+    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(BmPlTableModel::dbBmPl_Duration, durationColSize);
+    ui->tableViewBmPlaylist->horizontalHeader()->setSectionResizeMode(BmPlTableModel::dbBmPl_Position,QHeaderView::Fixed);
+    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(BmPlTableModel::dbBmPl_Position, iconWidth);
+    ui->tableViewBmPlaylist->horizontalHeader()->setSectionResizeMode(BmPlTableModel::dbBmPl_Path, QHeaderView::Fixed);
+    ui->tableViewBmPlaylist->horizontalHeader()->resizeSection(BmPlTableModel::dbBmPl_Path, iconWidth);
 }
 
 

--- a/OpenKJ/mainwindow.h
+++ b/OpenKJ/mainwindow.h
@@ -118,6 +118,7 @@ private:
     int sortColDB;
     int sortDirDB;
     QString dbRtClickFile;
+    QModelIndex m_rtClickIndex;
     QString curSinger;
     QString curArtist;
     QString curTitle;
@@ -171,6 +172,7 @@ private slots:
     void on_lineEdit_returnPressed();
     void on_tableViewDB_doubleClicked(const QModelIndex &index);
     void on_buttonAddSinger_clicked();
+    void on_tableViewRotation_activated(const QModelIndex &index);
     void on_tableViewRotation_doubleClicked(const QModelIndex &index);
     void on_tableViewRotation_clicked(const QModelIndex &index);
     void on_tableViewQueue_doubleClicked(const QModelIndex &index);
@@ -205,11 +207,13 @@ private slots:
     void on_sliderProgress_sliderReleased();
     void setKeyChange();
     void toggleQueuePlayed();
+    void playFileNow();
     void regularNameConflict(QString name);
     void regularAddError(QString errorText);
     void previewCdg();
     void editSong();
     void markSongBad();
+    void addSongToQueue();
     void setShowBgImage(bool show);
     void onBgImageChange();
     void karaokeAATimerTimeout();
@@ -269,6 +273,8 @@ private slots:
     void on_tabWidget_currentChanged(int index);
     void databaseAboutToUpdate();
     void bmDatabaseAboutToUpdate();
+    void on_pushButtonActivateSinger_clicked();
+    void on_pushButtonPlayNow_clicked();
     void scutSearchActivated();
     void bmSongMoved(int oldPos, int newPos);
 
@@ -277,7 +283,10 @@ private slots:
     void on_sliderBmPosition_sliderReleased();
 
 protected:
+    bool checkChangeSong();
     void closeEvent(QCloseEvent *event);
+    void activateSinger(int singerId);
+    void playSongAtIndex(const QModelIndex &index);
 
     // QWidget interface
 protected:

--- a/OpenKJ/mainwindow.ui
+++ b/OpenKJ/mainwindow.ui
@@ -2691,7 +2691,7 @@ QPushButton:default {
    </widget>
    <widget class="QMenu" name="menuKaraoke">
     <property name="title">
-     <string>Karaoke</string>
+     <string>&amp;Karaoke</string>
     </property>
     <addaction name="actionManage_Karaoke_DB"/>
     <addaction name="actionRegulars"/>
@@ -2704,11 +2704,11 @@ QPushButton:default {
    </widget>
    <widget class="QMenu" name="menuBreak_Music">
     <property name="title">
-     <string>Break Music</string>
+     <string>Break &amp;Music</string>
     </property>
     <widget class="QMenu" name="menuPlaylists">
      <property name="title">
-      <string>Playlist</string>
+      <string>&amp;Playlist</string>
      </property>
      <addaction name="actionPlaylistNew"/>
      <addaction name="actionPlaylistImport"/>
@@ -2722,7 +2722,7 @@ QPushButton:default {
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
-     <string>Help</string>
+     <string>He&amp;lp</string>
     </property>
     <addaction name="actionAbout"/>
    </widget>
@@ -2745,17 +2745,17 @@ QPushButton:default {
   </action>
   <action name="actionRegulars">
    <property name="text">
-    <string>Regulars</string>
+    <string>&amp;Regulars</string>
    </property>
   </action>
   <action name="actionIncoming_Requests">
    <property name="text">
-    <string>Incoming Requests</string>
+    <string>I&amp;ncoming Requests</string>
    </property>
   </action>
   <action name="actionSettings">
    <property name="text">
-    <string>Settings</string>
+    <string>&amp;Settings</string>
    </property>
   </action>
   <action name="actionExport_Regular_Singers">
@@ -2765,22 +2765,22 @@ QPushButton:default {
   </action>
   <action name="actionExport_Regulars">
    <property name="text">
-    <string>Export Regulars</string>
+    <string>&amp;Export Regulars</string>
    </property>
   </action>
   <action name="actionImport_Regulars">
    <property name="text">
-    <string>Import Regulars</string>
+    <string>&amp;Import Regulars</string>
    </property>
   </action>
   <action name="actionManage_Break_DB">
    <property name="text">
-    <string>Manage Break DB</string>
+    <string>&amp;Manage Break DB</string>
    </property>
   </action>
   <action name="actionManage_Karaoke_DB">
    <property name="text">
-    <string>Manage Karaoke DB</string>
+    <string>&amp;Manage Karaoke DB</string>
    </property>
   </action>
   <action name="actionRegulars_2">
@@ -2798,7 +2798,7 @@ QPushButton:default {
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Display Metadata</string>
+    <string>&amp;Display Metadata</string>
    </property>
   </action>
   <action name="actionDisplay_Filenames">
@@ -2806,32 +2806,32 @@ QPushButton:default {
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Display Filenames</string>
+    <string>Display &amp;Filenames</string>
    </property>
   </action>
   <action name="actionPlaylistNew">
    <property name="text">
-    <string>New</string>
+    <string>&amp;New</string>
    </property>
   </action>
   <action name="actionPlaylistImport">
    <property name="text">
-    <string>Import</string>
+    <string>&amp;Import</string>
    </property>
   </action>
   <action name="actionPlaylistExport">
    <property name="text">
-    <string>Export Current</string>
+    <string>&amp;Export Current</string>
    </property>
   </action>
   <action name="actionPlaylistDelete">
    <property name="text">
-    <string>Delete Current</string>
+    <string>&amp;Delete Current</string>
    </property>
   </action>
   <action name="actionAbout">
    <property name="text">
-    <string>About</string>
+    <string>&amp;About</string>
    </property>
   </action>
   <action name="actionAutoplay_mode">
@@ -2839,22 +2839,22 @@ QPushButton:default {
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Autoplay mode</string>
+    <string>&amp;Autoplay mode</string>
    </property>
   </action>
   <action name="actionSongbook_Generator">
    <property name="text">
-    <string>Songbook Generator</string>
+    <string>Songbook &amp;Generator</string>
    </property>
   </action>
   <action name="actionEqualizer">
    <property name="text">
-    <string>Equalizer</string>
+    <string>&amp;Equalizer</string>
    </property>
   </action>
   <action name="actionSong_Shop">
    <property name="text">
-    <string>Song Shop</string>
+    <string>&amp;Song Shop</string>
    </property>
   </action>
  </widget>

--- a/OpenKJ/mainwindow.ui
+++ b/OpenKJ/mainwindow.ui
@@ -554,6 +554,20 @@ QPushButton:default {
                       </property>
                      </spacer>
                     </item>
+                    <item>
+                     <widget class="QPushButton" name="pushButtonPlayNow">
+                      <property name="text">
+                       <string>Play Now</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="pushButtonActivateSinger">
+                      <property name="text">
+                       <string>Make Active</string>
+                      </property>
+                     </widget>
+                    </item>
                    </layout>
                   </widget>
                  </item>
@@ -2658,7 +2672,7 @@ QPushButton:default {
      <x>0</x>
      <y>0</y>
      <width>1309</width>
-     <height>25</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/OpenKJ/queuemodel.h
+++ b/OpenKJ/queuemodel.h
@@ -35,6 +35,18 @@ private:
 
 public:
     explicit QueueModel(QObject *parent = 0, QSqlDatabase db = QSqlDatabase());
+    enum {
+	 dbQueue_Qsongid = 0,
+	 dbQueue_Singer = 1,
+	 dbQueue_Song = 2,
+	 dbQueue_Artist = 3,
+	 dbQueue_Title = 4,
+	 dbQueue_Discid = 5,
+	 dbQueue_Path = 6,
+	 dbQueue_Keychg = 7,
+	 dbQueue_Played = 8,
+	 dbQueue_Position = 9
+	};
     void setSinger(int singerId);
     int singer();
     int getSongPosition(int songId);

--- a/OpenKJ/rotationmodel.h
+++ b/OpenKJ/rotationmodel.h
@@ -35,6 +35,14 @@ private:
 public:
     explicit RotationModel(QObject *parent = 0, QSqlDatabase db = QSqlDatabase());
     enum {ADD_FAIR=0,ADD_BOTTOM,ADD_NEXT};
+    enum {
+	 dbRotation_Singerid =0,
+	 dbRotation_Name=1,
+	 dbRotation_Position=2,
+	 dbRotation_Regular=3,
+	 dbRotation_Regularid=4
+	};
+
     int singerAdd(QString name);
     int singerCount;
     void singerMove(int oldPosition, int newPosition);


### PR DESCRIPTION
I'm not really expecting this to be merged as one, but more as a placeholder for you to review a series of small changes/commits I've made, and to make some comments.

* Tidy a couple of warnings
  * Unused parameter
  * C++ flag warnings (I've made this conditional on QT version)
* The buttons/menus commit pulled out from the activate/double-click commit. (Could be broken down even further if you wanted.
* The auto-added shortcuts (I didn't do these, they were added automatically, but seem sensible)
* Using Enums for columns rather than having magic 'column' numbers spread everywhere.
  * I'm happy to rework a different naming convention on this, but I think it makes things a lot easier to read
* Icon panel width.  In my environment the icon panel always has a horizontal scroll; this fixes that.