### PR TITLE
Move single instance checker out of MainWindow. Change implementation…

### DIFF
--- a/OpenKJ/OpenKJ.pro
+++ b/OpenKJ/OpenKJ.pro
@@ -188,6 +188,7 @@ SOURCES += main.cpp\
     karaokefileinfo.cpp \
     dlgeditsong.cpp \
     soundfxbutton.cpp \
+    runguard/runguard.cpp
     durationlazyupdater.cpp \
     idledetect.cpp \
     dlgdebugoutput.cpp
@@ -359,6 +360,7 @@ HEADERS  += mainwindow.h \
     karaokefileinfo.h \
     dlgeditsong.h \
     soundfxbutton.h \
+    runguard/runguard.h
     tableviewtooltipfilter.h \
     durationlazyupdater.h \
     idledetect.h \

--- a/OpenKJ/OpenKJ.pro
+++ b/OpenKJ/OpenKJ.pro
@@ -188,7 +188,7 @@ SOURCES += main.cpp\
     karaokefileinfo.cpp \
     dlgeditsong.cpp \
     soundfxbutton.cpp \
-    runguard/runguard.cpp
+    runguard/runguard.cpp \
     durationlazyupdater.cpp \
     idledetect.cpp \
     dlgdebugoutput.cpp
@@ -360,7 +360,7 @@ HEADERS  += mainwindow.h \
     karaokefileinfo.h \
     dlgeditsong.h \
     soundfxbutton.h \
-    runguard/runguard.h
+    runguard/runguard.h \
     tableviewtooltipfilter.h \
     durationlazyupdater.h \
     idledetect.h \

--- a/OpenKJ/main.cpp
+++ b/OpenKJ/main.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2013-2019 Thomas Isaac Lightburn
  *
  *
@@ -130,6 +130,8 @@ int main(int argc, char *argv[])
 //        return 1;
 //    }
 //#endif
+
+    MainWindow w;
     w.show();
 
     return a.exec();

--- a/OpenKJ/main.cpp
+++ b/OpenKJ/main.cpp
@@ -29,6 +29,7 @@
 #include <QMessageBox>
 #include "settings.h"
 #include "idledetect.h"
+#include "runguard/runguard.h"
 
 QDataStream &operator<<(QDataStream &out, const SfxEntry &obj)
 {
@@ -106,16 +107,17 @@ int main(int argc, char *argv[])
 //    file.close();
 //    stylesheet = "* { background: #191919; color: #DDDDDD; border: 1px solid #5A5A5A;}";
 //    a.setStyleSheet(stylesheet);
-    MainWindow w;
-    if (!w.isSingleInstance())
-    {
-        QMessageBox msgBox;
-        msgBox.setText("OpenKJ is already running!");
-        msgBox.setInformativeText("In order to protect the database, you can only run one instance of OpenKJ at a time.\nExiting now.");
-        msgBox.setIcon(QMessageBox::Critical);
-        msgBox.exec();
-        return 1;
-    }
+
+    RunGuard guard("SharedMemorySingleInstanceProtectorOpenKJ");
+     if (!guard.tryToRun())
+     {
+         QMessageBox msgBox;
+         msgBox.setText("OpenKJ is already running!");
+         msgBox.setInformativeText("In order to protect the database, you can only run one instance of OpenKJ at a time.\nExiting now.");
+         msgBox.setIcon(QMessageBox::Critical);
+         msgBox.exec();
+         return 1;
+     }
 //#ifdef MACPLATFORM
 //    if (!QFile::exists("/Library/Frameworks/GStreamer.framework"))
 //    {

--- a/OpenKJ/mainwindow.cpp
+++ b/OpenKJ/mainwindow.cpp
@@ -146,18 +146,6 @@ void MainWindow::updateIcons()
 }
 
 
-
-bool MainWindow::isSingleInstance()
-{
-    if(_singular->attach(QSharedMemory::ReadOnly)){
-        _singular->detach();
-        return false;
-    }
-    if(_singular->create(1))
-        return true;
-    return false;
-}
-
 QFile *logFile;
 QTextStream logStream;
 QStringList *logContents;
@@ -237,7 +225,6 @@ MainWindow::MainWindow(QWidget *parent) :
     _singular->attach();
     delete _singular;
 #endif
-    _singular = new QSharedMemory("SharedMemorySingleInstanceProtectorOpenKJ", this);
     shop = new SongShop(this);
     QCoreApplication::setOrganizationName("OpenKJ");
     QCoreApplication::setOrganizationDomain("OpenKJ.org");
@@ -908,8 +895,6 @@ MainWindow::~MainWindow()
     delete khTmpDir;
     delete dlgSongShop;
     delete requestsDialog;
-    if(_singular->isAttached())
-        _singular->detach();
 
     qInfo() << "OpenKJ mainwindow destructor complete";
 }

--- a/OpenKJ/mainwindow.cpp
+++ b/OpenKJ/mainwindow.cpp
@@ -218,13 +218,6 @@ MainWindow::MainWindow(QWidget *parent) :
     debugDialog->setVisible(settings->logShow());
     logFile = new QFile();
     qInstallMessageHandler(myMessageOutput);
-#ifndef Q_OS_WIN
-    // This fixes the program refusing to start and reporting another running instance after a crash on Linux
-    // and Mac until you try it twice.
-    _singular = new QSharedMemory("SharedMemorySingleInstanceProtectorOpenKJ", this);
-    _singular->attach();
-    delete _singular;
-#endif
     shop = new SongShop(this);
     QCoreApplication::setOrganizationName("OpenKJ");
     QCoreApplication::setOrganizationDomain("OpenKJ.org");

--- a/OpenKJ/mainwindow.h
+++ b/OpenKJ/mainwindow.h
@@ -138,7 +138,6 @@ private:
     QTimer m_timerSlowUiUpdate;
     QTimer m_timerButtonFlash;
     bool blinkRequestsBtn{false};
-    QSharedMemory *_singular;
     bool kNeedAutoSize{false};
     bool bNeedAutoSize{true};
     QShortcut scutAddSinger{this};

--- a/OpenKJ/runguard/runguard.cpp
+++ b/OpenKJ/runguard/runguard.cpp
@@ -1,0 +1,80 @@
+#include "runguard.h"
+
+#include <QCryptographicHash>
+
+
+namespace
+{
+
+    QString generateKeyHash( const QString& key, const QString& salt )
+    {
+        QByteArray data;
+
+        data.append( key.toUtf8() );
+        data.append( salt.toUtf8() );
+        data = QCryptographicHash::hash( data, QCryptographicHash::Sha1 ).toHex();
+
+        return data;
+    }
+
+}
+
+
+RunGuard::RunGuard( const QString& key )
+    : key( key )
+    , memLockKey( generateKeyHash( key, "_memLockKey" ) )
+    , sharedmemKey( generateKeyHash( key, "_sharedmemKey" ) )
+    , sharedMem( sharedmemKey )
+    , memLock( memLockKey, 1 )
+{
+    memLock.acquire();
+    {
+        QSharedMemory fix( sharedmemKey );    // Fix for *nix: http://habrahabr.ru/post/173281/
+        fix.attach();
+    }
+    memLock.release();
+}
+
+RunGuard::~RunGuard()
+{
+    release();
+}
+
+bool RunGuard::isAnotherRunning()
+{
+    if ( sharedMem.isAttached() )
+        return false;
+
+    memLock.acquire();
+    const bool isRunning = sharedMem.attach();
+    if ( isRunning )
+        sharedMem.detach();
+    memLock.release();
+
+    return isRunning;
+}
+
+bool RunGuard::tryToRun()
+{
+    if ( isAnotherRunning() )   // Extra check
+        return false;
+
+    memLock.acquire();
+    const bool result = sharedMem.create( sizeof( quint64 ) );
+    memLock.release();
+    if ( !result )
+    {
+        release();
+        return false;
+    }
+
+    return true;
+}
+
+void RunGuard::release()
+{
+    memLock.acquire();
+    if ( sharedMem.isAttached() )
+        sharedMem.detach();
+    memLock.release();
+}

--- a/OpenKJ/runguard/runguard.h
+++ b/OpenKJ/runguard/runguard.h
@@ -1,0 +1,26 @@
+#include <QObject>
+#include <QSharedMemory>
+#include <QSystemSemaphore>
+
+
+class RunGuard
+{
+
+public:
+    RunGuard( const QString& key );
+    ~RunGuard();
+
+    bool isAnotherRunning();
+    bool tryToRun();
+    void release();
+
+private:
+    const QString key;
+    const QString memLockKey;
+    const QString sharedmemKey;
+
+    QSharedMemory sharedMem;
+    QSystemSemaphore memLock;
+
+    Q_DISABLE_COPY( RunGuard )
+};


### PR DESCRIPTION
… to work when program forcefully closed or crashed

Code taken from: https://stackoverflow.com/questions/5006547/qt-best-practice-for-a-single-instance-app-protection