### PR TITLE
8 bit cdg images

### DIFF
--- a/OpenKJ/OpenKJ.pro
+++ b/OpenKJ/OpenKJ.pro
@@ -10,7 +10,9 @@ CONFIG += c++17
 
 unix:!macx {
     unix:DISTVER = $$system(cat /etc/os-release |grep VERSION_ID |cut -d'=' -f2 | sed -e \'s/^\"//\' -e \'s/\"$//\')
-    message($$DISTVER)
+    !isEmpty(DISTVER) {
+      message($$DISTVER)
+    }
     isEmpty(PREFIX) {
       PREFIX=/usr
     }

--- a/OpenKJ/dlgsettings.cpp
+++ b/OpenKJ/dlgsettings.cpp
@@ -144,13 +144,13 @@ DlgSettings::DlgSettings(MediaBackend *AudioBackend, MediaBackend *BmAudioBacken
     ui->spinBoxCdgOffsetBottom->setValue(settings->cdgOffsetBottom());
     ui->spinBoxCdgOffsetLeft->setValue(settings->cdgOffsetLeft());
     ui->spinBoxCdgOffsetRight->setValue(settings->cdgOffsetRight());
-    ui->spinBoxSlideshowInterval->setValue(settings->slideShowInterval());
+    //ui->spinBoxSlideshowInterval->setValue(settings->slideShowInterval());
     connect(ui->spinBoxCdgOffsetTop, SIGNAL(valueChanged(int)), settings, SLOT(setCdgOffsetTop(int)));
     connect(ui->spinBoxCdgOffsetBottom, SIGNAL(valueChanged(int)), settings, SLOT(setCdgOffsetBottom(int)));
     connect(ui->spinBoxCdgOffsetLeft, SIGNAL(valueChanged(int)), settings, SLOT(setCdgOffsetLeft(int)));
     connect(ui->spinBoxCdgOffsetRight, SIGNAL(valueChanged(int)), settings, SLOT(setCdgOffsetRight(int)));
     connect(ui->spinBoxVideoOffset, SIGNAL(valueChanged(int)), settings, SLOT(setVideoOffsetMs(int)));
-    connect(ui->spinBoxSlideshowInterval, SIGNAL(valueChanged(int)), settings, SLOT(setSlideShowInterval(int)));
+    //connect(ui->spinBoxSlideshowInterval, SIGNAL(valueChanged(int)), settings, SLOT(setSlideShowInterval(int)));
     AudioRecorder recorder;
  //   QAudioRecorder audioRecorder;
     QStringList inputs = recorder.getDeviceList();

--- a/OpenKJ/dlgsettings.cpp
+++ b/OpenKJ/dlgsettings.cpp
@@ -144,13 +144,13 @@ DlgSettings::DlgSettings(MediaBackend *AudioBackend, MediaBackend *BmAudioBacken
     ui->spinBoxCdgOffsetBottom->setValue(settings->cdgOffsetBottom());
     ui->spinBoxCdgOffsetLeft->setValue(settings->cdgOffsetLeft());
     ui->spinBoxCdgOffsetRight->setValue(settings->cdgOffsetRight());
-    //ui->spinBoxSlideshowInterval->setValue(settings->slideShowInterval());
+    ui->spinBoxSlideshowInterval->setValue(settings->slideShowInterval());
     connect(ui->spinBoxCdgOffsetTop, SIGNAL(valueChanged(int)), settings, SLOT(setCdgOffsetTop(int)));
     connect(ui->spinBoxCdgOffsetBottom, SIGNAL(valueChanged(int)), settings, SLOT(setCdgOffsetBottom(int)));
     connect(ui->spinBoxCdgOffsetLeft, SIGNAL(valueChanged(int)), settings, SLOT(setCdgOffsetLeft(int)));
     connect(ui->spinBoxCdgOffsetRight, SIGNAL(valueChanged(int)), settings, SLOT(setCdgOffsetRight(int)));
     connect(ui->spinBoxVideoOffset, SIGNAL(valueChanged(int)), settings, SLOT(setVideoOffsetMs(int)));
-    //connect(ui->spinBoxSlideshowInterval, SIGNAL(valueChanged(int)), settings, SLOT(setSlideShowInterval(int)));
+    connect(ui->spinBoxSlideshowInterval, SIGNAL(valueChanged(int)), settings, SLOT(setSlideShowInterval(int)));
     AudioRecorder recorder;
  //   QAudioRecorder audioRecorder;
     QStringList inputs = recorder.getDeviceList();

--- a/OpenKJ/dlgvideopreview.cpp
+++ b/OpenKJ/dlgvideopreview.cpp
@@ -109,8 +109,13 @@ void DlgVideoPreview::playCdg(const QString &filename)
     pipeline = gst_pipeline_new("videoPreviewPl");
     auto appSrc = gst_element_factory_make("appsrc", "videoPreviewAS");
     g_object_set(G_OBJECT(appSrc), "caps",
-                 gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, "RGB16", "width", G_TYPE_INT, 288, "height",
-                                     G_TYPE_INT, 192, "framerate", GST_TYPE_FRACTION, 1, 30, NULL),
+                 gst_caps_new_simple(
+                     "video/x-raw",
+                     "format", G_TYPE_STRING, "RGB8P",
+                     "width", G_TYPE_INT, cdg::FRAME_DIM_CROPPED.width(),
+                     "height", G_TYPE_INT, cdg::FRAME_DIM_CROPPED.height(),
+                     "framerate", GST_TYPE_FRACTION, 1, 30,
+                     NULL),
                  NULL);
     g_object_set(G_OBJECT(appSrc), "stream-type", 1, "format", GST_FORMAT_TIME, NULL);
     auto videoConvert = gst_element_factory_make("videoconvert", "videoPreviewVC");

--- a/OpenKJ/libCDG/include/libCDG.h
+++ b/OpenKJ/libCDG/include/libCDG.h
@@ -215,7 +215,6 @@ public:
     QString md5HashByTime(const unsigned int ms);
     std::array<uchar, cdg::CDG_IMAGE_SIZE> videoFrameDataByIndex(const size_t frame);
     std::array<uchar, cdg::CDG_IMAGE_SIZE> videoFrameDataByTime(const unsigned int ms);
-    void setMemoryCompressionLevel(const int level) { m_memoryCompressionLevel = std::min(9, level); }
 protected:
 private:
     int m_tempo{100};
@@ -224,7 +223,6 @@ private:
     int m_borderRBytesOffset;
     int m_curVOffset;
     int m_curHOffset;
-    int m_memoryCompressionLevel{0};
     unsigned int m_position;
     unsigned int m_lastCDGCommandMS;
     bool m_needupdate;
@@ -233,7 +231,6 @@ private:
     QByteArray m_cdgData;
     std::array<uchar, cdg::CDG_IMAGE_SIZE> blank;
     inline constexpr static std::array<char,6> m_masks{0x20,0x10,0x08,0x04,0x02,0x01};
-    std::vector<QByteArray> m_frameArraysComp;
     std::vector<std::array<uchar, cdg::CDG_IMAGE_SIZE>> m_frameArrays;
     QImage m_image;
     constexpr static char m_subcodeMask = 0x3F;
@@ -246,7 +243,6 @@ private:
     void cmdBorderPreset(const cdg::CdgBorderPresetData &borderPreset);
     void cmdTileBlock(const cdg::CdgTileBlockData &tileBlockPacket, const cdg::TileBlockType &type);
     void cmdColors(const cdg::CdgColorsData &data,const cdg::CdgColorTables &table);
-    QImage getSafeArea();
     std::array<uchar, cdg::CDG_IMAGE_SIZE> getCroppedImagedata();
 };
 

--- a/OpenKJ/libCDG/include/libCDG.h
+++ b/OpenKJ/libCDG/include/libCDG.h
@@ -34,6 +34,17 @@
 
 namespace cdg {
 
+/* This is the size of the display as defined by the CDG specification.
+   The pixels in this region can be painted, and scrolling operations
+   rotate through this number of pixels. */
+const QSize FRAME_DIM_FULL= QSize(300, 216);
+
+
+/* This is the size of the screen that is actually intended to be
+   visible.  It is the center area of FRAME_DIM_FULL.  The remaining border
+   area surrounding it is not meant to be visible. */
+const QSize FRAME_DIM_CROPPED = QSize(288, 192);
+
 // H x W + palette
 const int CDG_IMAGE_SIZE = 288 * 192 + 1024;
 
@@ -236,6 +247,7 @@ private:
     void cmdTileBlock(const cdg::CdgTileBlockData &tileBlockPacket, const cdg::TileBlockType &type);
     void cmdColors(const cdg::CdgColorsData &data,const cdg::CdgColorTables &table);
     QImage getSafeArea();
+    std::array<uchar, cdg::CDG_IMAGE_SIZE> getCroppedImagedata();
 };
 
 #endif // LIBCDG_H

--- a/OpenKJ/libCDG/include/libCDG.h
+++ b/OpenKJ/libCDG/include/libCDG.h
@@ -34,10 +34,8 @@
 
 namespace cdg {
 
-//  Using the known buffer size of 110592 rather than calling the function every callback
-//  It's a "magic number" but can be derived like below if ever in question
-//  auto bufferSize = backend->m_cdg.videoFrameByIndex(backend->curFrame).sizeInBytes();
-const int CDG_IMAGE_SIZE = 110592;
+// H x W + palette
+const int CDG_IMAGE_SIZE = 288 * 192 + 1024;
 
 enum ProcessingMode {
     File,

--- a/OpenKJ/libCDG/include/libCDG.h
+++ b/OpenKJ/libCDG/include/libCDG.h
@@ -34,6 +34,11 @@
 
 namespace cdg {
 
+//  Using the known buffer size of 110592 rather than calling the function every callback
+//  It's a "magic number" but can be derived like below if ever in question
+//  auto bufferSize = backend->m_cdg.videoFrameByIndex(backend->curFrame).sizeInBytes();
+const int CDG_IMAGE_SIZE = 110592;
+
 enum ProcessingMode {
     File,
     QIODevice
@@ -199,8 +204,8 @@ public:
     void setTempo(const int percent);
     std::size_t getFrameCount();
     QString md5HashByTime(const unsigned int ms);
-    std::array<uchar, 110592> videoFrameDataByIndex(const size_t frame);
-    std::array<uchar, 110592> videoFrameDataByTime(const unsigned int ms);
+    std::array<uchar, cdg::CDG_IMAGE_SIZE> videoFrameDataByIndex(const size_t frame);
+    std::array<uchar, cdg::CDG_IMAGE_SIZE> videoFrameDataByTime(const unsigned int ms);
     void setMemoryCompressionLevel(const int level) { m_memoryCompressionLevel = std::min(9, level); }
 protected:
 private:
@@ -217,10 +222,10 @@ private:
     bool m_isOpen;
     bool m_lastCmdWasMempreset;
     QByteArray m_cdgData;
-    std::array<uchar, 110592> blank;
+    std::array<uchar, cdg::CDG_IMAGE_SIZE> blank;
     inline constexpr static std::array<char,6> m_masks{0x20,0x10,0x08,0x04,0x02,0x01};
     std::vector<QByteArray> m_frameArraysComp;
-    std::vector<std::array<uchar, 110592>> m_frameArrays;
+    std::vector<std::array<uchar, cdg::CDG_IMAGE_SIZE>> m_frameArrays;
     QImage m_image;
     constexpr static char m_subcodeMask = 0x3F;
     constexpr static char m_subcodeCommand = 0x09;

--- a/OpenKJ/libCDG/src/libCDG.cpp
+++ b/OpenKJ/libCDG/src/libCDG.cpp
@@ -118,11 +118,11 @@ bool CdgParser::process()
         if (((position() % 40) == 0) && position() >= 40)
         {
             if (m_memoryCompressionLevel > 0)
-                m_frameArraysComp.emplace_back(qCompress(getSafeArea().convertToFormat(QImage::Format_RGB16).bits(),110592,1));
+                m_frameArraysComp.emplace_back(qCompress(getSafeArea().convertToFormat(QImage::Format_RGB16).bits(), cdg::CDG_IMAGE_SIZE, 1));
             else
             {
-                std::array<uchar, 110592> frameArr;
-                memcpy(frameArr.data(),getSafeArea().convertToFormat(QImage::Format_RGB16).bits(),110592);
+                std::array<uchar, cdg::CDG_IMAGE_SIZE> frameArr;
+                memcpy(frameArr.data(),getSafeArea().convertToFormat(QImage::Format_RGB16).bits(), cdg::CDG_IMAGE_SIZE);
                 m_frameArrays.emplace_back(frameArr);
             }
             frameno++;
@@ -323,12 +323,12 @@ std::size_t CdgParser::getFrameCount() {
     return retSize;
 }
 
-std::array<uchar, 110592> CdgParser::videoFrameDataByTime(const unsigned int ms)
+std::array<uchar, cdg::CDG_IMAGE_SIZE> CdgParser::videoFrameDataByTime(const unsigned int ms)
 {
     return videoFrameDataByIndex((ms * ((float)m_tempo / 100.0)) / 40);
 }
 
-std::array<uchar, 110592> CdgParser::videoFrameDataByIndex(const size_t frame)
+std::array<uchar, cdg::CDG_IMAGE_SIZE> CdgParser::videoFrameDataByIndex(const size_t frame)
 {
     if ((m_memoryCompressionLevel > 0 && frame >= m_frameArraysComp.size()) || (m_memoryCompressionLevel == 0 && frame >= m_frameArrays.size()))
     {
@@ -336,8 +336,8 @@ std::array<uchar, 110592> CdgParser::videoFrameDataByIndex(const size_t frame)
     }
     if (m_memoryCompressionLevel > 0)
     {
-        std::array<uchar, 110592> frameArr;
-        memcpy(frameArr.data(),qUncompress(m_frameArraysComp.at(frame)).data(), 110592);
+        std::array<uchar, cdg::CDG_IMAGE_SIZE> frameArr;
+        memcpy(frameArr.data(),qUncompress(m_frameArraysComp.at(frame)).data(), cdg::CDG_IMAGE_SIZE);
         return frameArr;
     }
     return m_frameArrays.at(frame);

--- a/OpenKJ/mainwindow.cpp
+++ b/OpenKJ/mainwindow.cpp
@@ -706,7 +706,6 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->labelVolumeBm->setPixmap(QIcon::fromTheme("player-volume").pixmap(QSize(22,22)));
     updateIcons();
     ui->menuTesting->menuAction()->setVisible(settings->testingEnabled());
-    kMediaBackend.setCdgMemoryCompressionLevel(settings->cdgMemoryCompressionLevel());
     connect(&kMediaBackend, &MediaBackend::newVideoFrame, this, &MainWindow::videoFrameReceived);
     connect(&bmMediaBackend, &MediaBackend::newVideoFrame, this, &MainWindow::videoFrameReceived);
 }

--- a/OpenKJ/mediabackend.cpp
+++ b/OpenKJ/mediabackend.cpp
@@ -1016,7 +1016,6 @@ void MediaBackend::cb_need_data(GstElement *appsrc, [[maybe_unused]]guint unused
         }
         g_appSrcCurPosition += 40 * GST_MSECOND;
         g_appSrcCurFrame++;
-        QApplication::processEvents();
     }
 
     //qInfo() << "curFrame: " << g_appSrcCurFrame << " total frames: " << backend->m_cdg.getFrameCount();

--- a/OpenKJ/mediabackend.cpp
+++ b/OpenKJ/mediabackend.cpp
@@ -945,10 +945,8 @@ void MediaBackend::buildCdgBin()
         g_object_set(m_videoAppSinkCdg, "caps", videoCaps, NULL);
         gst_app_sink_set_callbacks(GST_APP_SINK(m_videoAppSinkCdg), &appsinkCallbacks, this, (GDestroyNotify)MediaBackend::DestroyCallback);
         auto videoQueue = gst_element_factory_make("queue", "cdgVideoQueue");
-        auto videoScale = gst_element_factory_make("videoscale", "cdgVideoScale");
-        auto videoConvert = gst_element_factory_make("videoconvert", "cdgVideoConvert");
-        gst_bin_add_many(reinterpret_cast<GstBin *>(m_cdgBin), m_cdgAppSrc, videoQueue, videoConvert, videoScale, m_videoAppSinkCdg, nullptr);
-        gst_element_link_many(m_cdgAppSrc, videoQueue, videoConvert, videoScale, m_videoAppSinkCdg, nullptr);
+        gst_bin_add_many(reinterpret_cast<GstBin *>(m_cdgBin), m_cdgAppSrc, videoQueue, m_videoAppSinkCdg, nullptr);
+        gst_element_link_many(m_cdgAppSrc, videoQueue, m_videoAppSinkCdg, nullptr);
     }
 }
 

--- a/OpenKJ/mediabackend.cpp
+++ b/OpenKJ/mediabackend.cpp
@@ -900,7 +900,7 @@ void MediaBackend::buildCdgBin()
     m_cdgAppSrc = gst_element_factory_make("appsrc", "cdgAppSrc");
     auto cdgVidConv = gst_element_factory_make("videoconvert", "cdgVideoConv");
     g_object_set(G_OBJECT(m_cdgAppSrc), "caps",
-                 gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, "RGB16", "width", G_TYPE_INT, 288, "height",
+                 gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, "RGB8P", "width", G_TYPE_INT, 288, "height",
                                      G_TYPE_INT, 192, NULL),
                  NULL);
 
@@ -934,7 +934,7 @@ void MediaBackend::buildCdgBin()
         appsinkCallbacks.new_sample		= &MediaBackend::NewSampleCallbackCdg;
         appsinkCallbacks.eos			= &MediaBackend::EndOfStreamCallback;
         m_videoAppSinkCdg = gst_element_factory_make("appsink", "videoAppSinkCdg");
-        auto videoCaps = gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, "RGB16", NULL);
+        auto videoCaps = gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, "RGB8P", NULL);
         g_object_set(m_videoAppSinkCdg, "caps", videoCaps, NULL);
         gst_app_sink_set_callbacks(GST_APP_SINK(m_videoAppSinkCdg), &appsinkCallbacks, this, (GDestroyNotify)MediaBackend::DestroyCallback);
         auto videoQueue = gst_element_factory_make("queue", "cdgVideoQueue");

--- a/OpenKJ/mediabackend.cpp
+++ b/OpenKJ/mediabackend.cpp
@@ -238,7 +238,13 @@ void MediaBackend::newFrameCdg()
         GstMapInfo bufferInfo;
         gst_buffer_map(buffer,&bufferInfo,GST_MAP_READ);
         guint8 *rawFrame = bufferInfo.data;
-        QImage frame = QImage(rawFrame,width,height,QImage::Format_RGB16);
+
+        // Create indexed 8-bit image from buffer data. Last 1024 bytes is the color table
+        QImage frame = QImage(rawFrame, width, height, QImage::Format_Indexed8);
+        auto colors = QVector<QRgb>(1024 / sizeof(QRgb));
+        memcpy(colors.data(), rawFrame + bufferInfo.size - 1024, 1024);
+        frame.setColorTable(colors);
+
         emit newVideoFrame(frame, m_objName);
         gst_buffer_unmap(buffer, &bufferInfo);
         gst_sample_unref(sample);

--- a/OpenKJ/mediabackend.cpp
+++ b/OpenKJ/mediabackend.cpp
@@ -372,8 +372,8 @@ void MediaBackend::play()
         g_appSrcCurFrame = 0;
         g_appSrcCurPosition = 0;
         g_appSrcNeedData = false;
-        gst_app_src_set_max_bytes(reinterpret_cast<GstAppSrc*>(m_cdgAppSrc), 110592 * 500);
-        gst_app_src_set_size(reinterpret_cast<GstAppSrc*>(m_cdgAppSrc), m_cdg.getFrameCount() * 110592);
+        gst_app_src_set_max_bytes(reinterpret_cast<GstAppSrc*>(m_cdgAppSrc), cdg::CDG_IMAGE_SIZE * 500);
+        gst_app_src_set_size(reinterpret_cast<GstAppSrc*>(m_cdgAppSrc), m_cdg.getFrameCount() * cdg::CDG_IMAGE_SIZE);
         gst_app_src_set_duration(reinterpret_cast<GstAppSrc*>(m_cdgAppSrc), (m_cdg.getFrameCount() * 40) * GST_MSECOND);
         qInfo() << m_objName << " - play - playing cdg:   " << m_cdgFilename;
         qInfo() << m_objName << " - play - playing audio: " << m_filename;
@@ -977,23 +977,20 @@ void MediaBackend::cb_enough_data([[maybe_unused]]GstElement *appsrc, [[maybe_un
 void MediaBackend::cb_need_data(GstElement *appsrc, [[maybe_unused]]guint unused_size, gpointer user_data)
 {
     auto backend = reinterpret_cast<MediaBackend *>(user_data);
-//  Using the known buffer size of 110592 rather than calling the function every callback
-//  It's a "magic number" but can be derived like below if ever in question
-//    auto bufferSize = backend->m_cdg.videoFrameByIndex(backend->curFrame).sizeInBytes();
     g_appSrcNeedData = true;
     //qInfo() << "cdg buffering - free space: " << unused_size;
     while (g_appSrcNeedData && g_appSrcCurFrame < backend->m_cdg.getFrameCount())
     {
-        auto buffer = gst_buffer_new_and_alloc(110592);
+        auto buffer = gst_buffer_new_and_alloc(cdg::CDG_IMAGE_SIZE);
 //        gst_buffer_fill(buffer,
 //                        0,
 //                        backend->m_cdg.videoFrameByIndex(adjustedFrame).constBits(),
-//                        110592
+//                        cdg::CDG_IMAGE_SIZE
 //                        );
         gst_buffer_fill(buffer,
                         0,
                         backend->m_cdg.videoFrameDataByTime((g_appSrcCurPosition / GST_MSECOND) + backend->m_videoOffsetMs).data(),
-                        110592
+                        cdg::CDG_IMAGE_SIZE
                         );
         GST_BUFFER_TIMESTAMP(buffer) = g_appSrcCurPosition;
         //GST_BUFFER_PTS(buffer) = g_appSrcCurPosition;

--- a/OpenKJ/mediabackend.h
+++ b/OpenKJ/mediabackend.h
@@ -82,7 +82,6 @@ public:
     qint64 position();
     qint64 duration();
     State state();
-    void setCdgMemoryCompressionLevel(int level) { m_cdg.setMemoryCompressionLevel(level); }
     QStringList getOutputDevices() { return m_outputDeviceNames; }
     QString msToMMSS(const qint64 &msec)
     {

--- a/OpenKJ/settings.cpp
+++ b/OpenKJ/settings.cpp
@@ -1125,21 +1125,6 @@ int Settings::videoOffsetMs()
     return settings->value("videoOffsetMs", 0).toInt();
 }
 
-int Settings::cdgMemoryCompressionLevel()
-{
-    auto ramSize = getSystemRamSize();
-    qInfo() << "RAM size: " << ramSize;
-    if (ramSize < 6000000 && ramSize != 0 && !settings->contains("cdgMemoryCompressionLevel"))
-    {
-        qInfo() << "System physical RAM < 6GB, defaulting cdg ram compression to lvl 1";
-        return settings->value("cdgMemoryCompressionLevel", 1).toInt();
-    }
-    else
-    {
-        return settings->value("cdgMemoryCompressionLevel", 0).toInt();
-    }
-}
-
 void Settings::setIgnoreAposInSearch(bool ignore)
 {
     settings->setValue("ignoreAposInSearch", ignore);

--- a/OpenKJ/settings.h
+++ b/OpenKJ/settings.h
@@ -190,7 +190,6 @@ public:
     int cdgOffsetRight();
     bool ignoreAposInSearch();
     int videoOffsetMs();
-    int cdgMemoryCompressionLevel();
     bool bmShowFilenames();
     void bmSetShowFilenames(bool show);
     bool bmShowMetadata();


### PR DESCRIPTION
Store images as 8-bit indexed images instead of RGB. This cuts down memory usage from caching cdg-frames by 50% (!!!)

I had to clean up video converters in the gstreamer pipeline due to some weird image artifacts. I think however it is more correct now anyways.

I got tired of looking at the cdg compression code, so got rid of that. Look at the separate commit if you want it back :-)

Partly fixes #212