### PR TITLE
Bugfix: cdg last frame not rendered

### DIFF
--- a/src/cdg/cdgfilereader.cpp
+++ b/src/cdg/cdgfilereader.cpp
@@ -121,3 +121,24 @@ inline int CdgFileReader::getDurationOfPackagesInMS(const int numberOfPackages)
 {
     return (numberOfPackages * 1000) / CDG_PACKAGES_PER_SECOND;
 }
+
+#ifdef QT_DEBUG
+void CdgFileReader::saveNextImgToFile()
+{
+    auto fn = QString("/tmp/cdgimg/nxt-%1.png").arg(m_next_image_pgk_idx, 4, 10, QLatin1Char('0'));
+    m_next_image.getImage().save(fn);
+}
+
+void CdgFileReader::saveCurrentImgToFile()
+{
+    auto fn = QString("/tmp/cdgimg/cur-%1-%2-%3.png")
+            .arg(m_current_image_pgk_idx, 4, 10, QLatin1Char('0'))
+            .arg(currentFramePositionMS(), 4, 10, QLatin1Char('0'))
+            .arg(currentFrameDurationMS(), 4, 10, QLatin1Char('0'));
+    QImage img = QImage(m_current_image_data.data(), cdg::FRAME_DIM_CROPPED.width(), cdg::FRAME_DIM_CROPPED.height(), QImage::Format_Indexed8);
+    auto colors = QVector<QRgb>(1024 / sizeof(QRgb));
+    memcpy(colors.data(), m_current_image_data.data() + cdg::CDG_IMAGE_SIZE - 1024, 1024);
+    img.setColorTable(colors);
+    img.save(fn);
+}
+#endif

--- a/src/cdg/cdgfilereader.h
+++ b/src/cdg/cdgfilereader.h
@@ -44,6 +44,11 @@ public:
      */
     int positionOfFinalFrameMS();
 
+#ifdef QT_DEBUG
+    void saveNextImgToFile();
+    void saveCurrentImgToFile();
+#endif
+
 private:
     void rewind();
     bool readAndProcessNextPackage();
@@ -59,7 +64,6 @@ private:
 
     CdgImageFrame m_next_image;
     int m_next_image_pgk_idx;
-
 };
 
 #endif // CDGFILEREADER_H

--- a/src/cdg/cdgfilereader.h
+++ b/src/cdg/cdgfilereader.h
@@ -11,15 +11,16 @@ public:
     CdgFileReader(const QString &filename);
 
     /**
-     * @brief Replaces currentFrame() with the next frame with visible changes and
+     * @brief Read first/next frame from the data stream.
+     * @note  Replaces currentFrame() with the next frame with visible changes and
      * sets currentFrameDurationMS() and currentFramePositionMS() as well.
      * @return true if here are more frames to be read. false if EOF.
      */
     bool moveToNextFrame();
 
     std::array<uchar, cdg::CDG_IMAGE_SIZE> currentFrame() { return m_current_image_data; }
-    uint currentFrameDurationMS();
-    uint currentFramePositionMS();
+    int currentFrameDurationMS();
+    int currentFramePositionMS();
 
     /**
      * @brief Set currentFrame() to the frame that should be displayed at a given point in time.
@@ -27,13 +28,13 @@ public:
      * @param positionMS The position in milliseconds.
      * @return true is positionMS is within file range.
      */
-    bool seek(uint positionMS);
+    bool seek(int positionMS);
 
     /**
      * @brief Duration of the entire file in milliseconds
      * @return
      */
-    uint getTotalDurationMS();
+    int getTotalDurationMS();
 
     /**
      * Returns the position of the very last frame.
@@ -48,16 +49,16 @@ private:
     bool readAndProcessNextPackage();
     inline bool isEOF();
 
-    inline static uint getDurationOfPackagesInMS(const uint numberOfPackages);
+    inline static int getDurationOfPackagesInMS(const int numberOfPackages);
 
     QByteArray m_cdgData;
-    unsigned int m_cdgDataPos;
+    int m_cdgDataPos;
 
     std::array<uchar, cdg::CDG_IMAGE_SIZE> m_current_image_data;
-    unsigned int m_current_image_pgk_idx;
+    int m_current_image_pgk_idx;
 
     CdgImageFrame m_next_image;
-    unsigned int m_next_image_pgk_idx;
+    int m_next_image_pgk_idx;
 
 };
 

--- a/src/cdg/cdgimageframe.h
+++ b/src/cdg/cdgimageframe.h
@@ -14,6 +14,8 @@ public:
 
     void copyCroppedImagedata(uchar *destbuffer);
 
+    QImage getImage() { return m_image; }
+
 private:
 
     QImage m_image;


### PR DESCRIPTION
This fixes a bug in the new cdg reader implementation that caused the cdg frames to be offset by -1.
This was visible when showing logos and other things where the same frame is displayed for some time.