### PR TITLE
Cdg silence detection

### DIFF
--- a/src/cdg/cdgappsrc.cpp
+++ b/src/cdg/cdgappsrc.cpp
@@ -57,11 +57,6 @@ void CdgAppSrc::load(const QString filename)
     gst_app_src_set_duration(m_cdgAppSrc, m_cdgFileReader->getTotalDurationMS() * GST_MSECOND);
 }
 
-int CdgAppSrc::getLastDrawPosition()
-{
-    return m_cdgFileReader->positionOfFinalDrawMS();
-}
-
 int CdgAppSrc::positionOfFinalFrameMS()
 {
     QMutexLocker locker(&m_cdgFileReaderLock);

--- a/src/cdg/cdgappsrc.h
+++ b/src/cdg/cdgappsrc.h
@@ -28,7 +28,7 @@ public:
     GstElement* getSrcElement();
     void reset();
     void load(const QString filename);
-    int getLastDrawPosition();
+
     /**
      * Returns the position of the very last frame.
      * This can be less than the total duration, beceause: "total duration = position + duration of final frame".

--- a/src/cdg/cdgfilereader.cpp
+++ b/src/cdg/cdgfilereader.cpp
@@ -24,7 +24,7 @@ int CdgFileReader::getTotalDurationMS()
 
 int CdgFileReader::positionOfFinalFrameMS()
 {
-    return isEOF() ? currentFramePositionMS() : -1;
+    return isEOF() ? getDurationOfPackagesInMS(m_last_image_change_pgk_idx) : -1;
 }
 
 bool CdgFileReader::moveToNextFrame()
@@ -56,7 +56,12 @@ bool CdgFileReader::moveToNextFrame()
         {
             return true;
         }
-        imageChanged |= readAndProcessNextPackage();
+
+        if(readAndProcessNextPackage())
+        {
+            imageChanged = true;
+            m_last_image_change_pgk_idx = m_next_image_pgk_idx;
+        }
     }
 }
 
@@ -101,6 +106,7 @@ void CdgFileReader::rewind()
     m_current_image_pgk_idx = 0;
     m_next_image = CdgImageFrame();
     m_next_image_pgk_idx = 0;
+    m_last_image_change_pgk_idx = -1;
 }
 
 bool CdgFileReader::readAndProcessNextPackage()

--- a/src/cdg/cdgfilereader.cpp
+++ b/src/cdg/cdgfilereader.cpp
@@ -1,7 +1,6 @@
 #include "cdgfilereader.h"
 #include <QFile>
 #include <QDebug>
-#include <QBuffer>
 
 
 constexpr int CDG_PACKAGES_PER_SECOND = 300;
@@ -14,7 +13,7 @@ CdgFileReader::CdgFileReader(const QString &filename)
     QFile file(filename);
     file.open(QFile::ReadOnly);
     m_cdgData = file.readAll();
-    scanForFinalDrawPosition();
+
     rewind();
 }
 
@@ -23,44 +22,9 @@ int CdgFileReader::getTotalDurationMS()
     return getDurationOfPackagesInMS(m_cdgData.length() / (int)sizeof (cdg::CDG_SubCode));
 }
 
-void CdgFileReader::scanForFinalDrawPosition()
-{
-    QBuffer ioDevice(&m_cdgData);
-    auto getPos = [] (int position) {
-        float fpos = (position / 300.0) * 1000;
-        return (int) fpos;
-    };
-    int frameNo{0};
-    unsigned int position{0};
-    cdg::CDG_SubCode subCode;
-    const char subcodeMask = 0x3F;
-    const char subcodeCommand = 0x09;
-
-    if (!ioDevice.open(QIODevice::ReadOnly))
-    {
-        m_lastDrawPosMs = -1;
-        return;
-    }
-
-    while (ioDevice.read((char *)&subCode, sizeof(subCode)) > 0) {
-        if ((subCode.command & subcodeMask) == subcodeCommand)
-            m_lastDrawPosMs = frameNo * 40;
-        position++;
-        if (auto pos = getPos(position); ((pos % 40) == 0) && pos >= 40)
-            frameNo++;
-    }
-
-    qInfo() << "CDG last draw pos: " << m_lastDrawPosMs << " Total len: " << getTotalDurationMS();
-}
-
 int CdgFileReader::positionOfFinalFrameMS()
 {
     return isEOF() ? currentFramePositionMS() : -1;
-}
-
-int CdgFileReader::positionOfFinalDrawMS() const
-{
-    return m_lastDrawPosMs;
 }
 
 bool CdgFileReader::moveToNextFrame()

--- a/src/cdg/cdgfilereader.h
+++ b/src/cdg/cdgfilereader.h
@@ -42,9 +42,7 @@ public:
      *
      * @return The value is not known until all data is read. If so, -1 is returned.
      */
-    void scanForFinalDrawPosition();
     int positionOfFinalFrameMS();
-    int positionOfFinalDrawMS() const;
 
 #ifdef QT_DEBUG
     void saveNextImgToFile();
@@ -66,7 +64,6 @@ private:
 
     CdgImageFrame m_next_image;
     int m_next_image_pgk_idx;
-    int m_lastDrawPosMs{0};
 };
 
 #endif // CDGFILEREADER_H

--- a/src/cdg/cdgfilereader.h
+++ b/src/cdg/cdgfilereader.h
@@ -64,6 +64,11 @@ private:
 
     CdgImageFrame m_next_image;
     int m_next_image_pgk_idx;
+
+    /**
+     * Index of the last read package that caused a visible image change.
+     */
+    int m_last_image_change_pgk_idx;
 };
 
 #endif // CDGFILEREADER_H

--- a/src/mediabackend.cpp
+++ b/src/mediabackend.cpp
@@ -472,10 +472,10 @@ void MediaBackend::timerSlow_timeout()
             {
                 if (m_type != Karaoke)
                     emit silenceDetected();
-                else if(auto lastDraw = m_cdgSrc->getLastDrawPosition(); m_cdgMode && lastDraw != -1)
+                else if(m_cdgMode && m_cdgSrc->positionOfFinalFrameMS() != -1)
                 {
                         // In CDG-karaoke mode, only cut of the song if there are no more image frames to be shown
-                        if (lastDraw > 0 && lastDraw <= currPos)
+                        if (m_cdgSrc->positionOfFinalFrameMS() > 0 && m_cdgSrc->positionOfFinalFrameMS() <= currPos)
                             emit silenceDetected();
                 }
             }

--- a/src/mediabackend.cpp
+++ b/src/mediabackend.cpp
@@ -471,12 +471,17 @@ void MediaBackend::timerSlow_timeout()
             if (m_silenceDuration++ >= 2)
             {
                 if (m_type != Karaoke)
-                    emit silenceDetected();
-                else if(m_cdgMode && m_cdgSrc->positionOfFinalFrameMS() != -1)
                 {
-                        // In CDG-karaoke mode, only cut of the song if there are no more image frames to be shown
-                        if (m_cdgSrc->positionOfFinalFrameMS() > 0 && m_cdgSrc->positionOfFinalFrameMS() <= currPos)
-                            emit silenceDetected();
+                    emit silenceDetected();
+                }
+                else if(m_cdgMode)
+                {
+                    // In CDG-karaoke mode, only cut of the song if there are no more image frames to be shown
+                    int last_frame_pos = m_cdgSrc->positionOfFinalFrameMS();
+                    if (last_frame_pos > 0 && last_frame_pos <= currPos)
+                    {
+                        emit silenceDetected();
+                    }
                 }
             }
         }


### PR DESCRIPTION
The new cdg implementation had working detection of the last frame change. This was however broken with 5b93889bdac837b78098739b8ebc96e71cfcd827.

A fix for that was introduced with 7faeeee9837590c6c1801d9870b77f38fd42b655. This fix however causes the entire file (in memory) to be read in one go on play start.

This PR is a fix to the original approach where the file is "streamed" as needed.